### PR TITLE
added invertYAxis feature

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -23,10 +23,12 @@ class BarChartData extends AxisChartData {
     FlBorderData borderData,
     double maxY,
     Color backgroundColor,
+    bool invertYAxis = false,
   }) : super(
           gridData: gridData,
           borderData: borderData,
           backgroundColor: backgroundColor,
+          invertYAxis: invertYAxis,
         ) {
     initSuperMinMaxValues(maxY);
   }

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -155,6 +155,10 @@ class BarChartPainter extends AxisChartPainter {
         double widthHalf = barRod.width / 2;
         double roundedRadius = barRod.isRound ? widthHalf : 0;
 
+        // we need to invert the rounded radius, so it's later removed/added
+        // properly (reduces further if/else) 
+        roundedRadius *= data.invertYAxis ? -1 : 1;
+
         double x = barsX[groupIndex] - (barGroup.width / 2) + tempX + widthHalf;
 
         Offset from, to;
@@ -205,7 +209,7 @@ class BarChartPainter extends AxisChartPainter {
             text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
         tp.layout(maxWidth: getExtraNeededHorizontalSpace());
         x -= tp.width + data.titlesData.verticalTitleMargin;
-        y -= (tp.height / 2);
+        y -= (tp.height / 2)+getTopOffsetDrawSize();
         tp.paint(canvas, Offset(x, y));
 
         verticalCounter++;
@@ -222,8 +226,10 @@ class BarChartPainter extends AxisChartPainter {
       tp.layout();
 
       double textX = x - (tp.width / 2);
-      double textY =
-          drawSize.height + getTopOffsetDrawSize() + data.titlesData.horizontalTitleMargin;
+      double textY = 4; // <-- this is a wild guess, please check and verify
+      if (data.invertYAxis == false) {
+        textY = drawSize.height + getTopOffsetDrawSize() + data.titlesData.horizontalTitleMargin;
+      }
 
       tp.paint(canvas, Offset(textX, textY));
     });
@@ -269,6 +275,17 @@ class BarChartPainter extends AxisChartPainter {
         data.titlesData.verticalTitleMargin;
     }
     return parentNeeded;
+  }
+
+  /// calculate top offset for draw the chart,
+  /// if the y axis is inverted, we just return the space that is used
+  /// for the horizontal titles
+  @override
+  double getTopOffsetDrawSize() {
+    if (data.invertYAxis) {
+      return getExtraNeededVerticalSpace();
+    }
+    return super.getTopOffsetDrawSize();
   }
 
   @override

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -20,6 +20,8 @@ class AxisChartData extends BaseChartData {
   /// A background color which is drawn behind th chart.
   Color backgroundColor;
 
+  bool invertYAxis;
+
   AxisChartData({
     this.gridData = const FlGridData(),
     FlBorderData borderData,
@@ -27,6 +29,7 @@ class AxisChartData extends BaseChartData {
     this.minY, this.maxY,
     this.clipToBorder = false,
     this.backgroundColor,
+    this.invertYAxis = false,
   }) : super(borderData: borderData);
 }
 

--- a/lib/src/chart/base/axis_chart/axis_chart_painter.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_painter.dart
@@ -38,13 +38,16 @@ abstract class AxisChartPainter<D extends AxisChartData> extends BaseChartPainte
       gridPaint.strokeWidth = data.gridData.verticalGridLineWidth;
 
       double verticalSeek = data.minY;
+      // precalculated top offset 
+      // no top offset when axis is inverted
+      final topOffset = data.invertYAxis ? 0 : getTopOffsetDrawSize();
       while (verticalSeek < data.maxY) {
         if (data.gridData.checkToShowVerticalGrid(verticalSeek)) {
           final double bothY = getPixelY(verticalSeek, usableViewSize);
           final double x1 = 0 + getLeftOffsetDrawSize();
-          final double y1 = bothY + getTopOffsetDrawSize();
+          final double y1 = bothY + topOffset;
           final double x2 = usableViewSize.width + getLeftOffsetDrawSize();
-          final double y2 = bothY + getTopOffsetDrawSize();
+          final double y2 = bothY + topOffset;
           canvas.drawLine(
             Offset(x1, y1),
             Offset(x2, y2),
@@ -113,7 +116,9 @@ abstract class AxisChartPainter<D extends AxisChartData> extends BaseChartPainte
     Size chartUsableSize,
   ) {
     double y = ((spotY - data.minY) / (data.maxY - data.minY)) * chartUsableSize.height;
-    y = chartUsableSize.height - y;
+    if (data.invertYAxis != true) {
+      y = chartUsableSize.height - y;
+    }
     return y + getTopOffsetDrawSize();
   }
 }

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -24,11 +24,13 @@ class LineChartData extends AxisChartData {
     double maxY,
     bool clipToBorder = false,
     Color backgroundColor,
+    bool invertYAxis = false,
   }) : super(
     gridData: gridData,
     borderData: borderData,
     clipToBorder: clipToBorder,
     backgroundColor: backgroundColor,
+    invertYAxis: invertYAxis,
   ) {
     initSuperMinMaxValues(minX, maxX, minY, maxY);
   }

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -140,15 +140,21 @@ class LineChartPainter extends AxisChartPainter {
     var belowBarPath = Path.from(barPath);
 
     Size chartViewSize = getChartUsableDrawSize(viewSize);
+ 
 
     /// Line To Bottom Right
     double x = getPixelX(barData.spots[barData.spots.length - 1].x, chartViewSize);
-    double y = chartViewSize.height - getTopOffsetDrawSize();
+    double y;
+    if (data.invertYAxis) {
+      y = getTopOffsetDrawSize();
+    } else {
+      y = chartViewSize.height - getTopOffsetDrawSize();
+    }
     belowBarPath.lineTo(x, y);
 
     /// Line To Bottom Left
     x = getPixelX(barData.spots[0].x, chartViewSize);
-    y = chartViewSize.height - getTopOffsetDrawSize();
+    // y = chartViewSize.height - getTopOffsetDrawSize(); <-- unneccesary since it's identical to the previous declaration
     belowBarPath.lineTo(x, y);
 
     /// Line To Top Left
@@ -306,11 +312,12 @@ class LineChartPainter extends AxisChartPainter {
 
     // Vertical Titles
     if (data.titlesData.showVerticalTitles) {
+      double yOffset = (data.invertYAxis) ? 0 : getTopOffsetDrawSize();
       double verticalSeek = data.minY;
       while (verticalSeek <= data.maxY) {
         double x = 0 + getLeftOffsetDrawSize();
         double y = getPixelY(verticalSeek, viewSize) +
-            getTopOffsetDrawSize();
+            yOffset;
 
         final String text =
             data.titlesData.getVerticalTitles(verticalSeek);
@@ -329,10 +336,14 @@ class LineChartPainter extends AxisChartPainter {
 
     // Horizontal titles
     if (data.titlesData.showHorizontalTitles) {
+      double baseY = 0;
+      if (data.invertYAxis == false) {
+        baseY = viewSize.height + getTopOffsetDrawSize();
+      }
       double horizontalSeek = data.minX;
       while (horizontalSeek <= data.maxX) {
         double x = getPixelX(horizontalSeek, viewSize);
-        double y = viewSize.height + getTopOffsetDrawSize();
+        double y = baseY;
 
         String text = data.titlesData
             .getHorizontalTitles(horizontalSeek);
@@ -432,6 +443,17 @@ class LineChartPainter extends AxisChartPainter {
         data.titlesData.verticalTitleMargin;
     }
     return parentNeeded;
+  }
+
+  /// calculate top offset for draw the chart,
+  /// if the y axis is inverted, we just return the space that is used
+  /// for the horizontal titles
+  @override
+  double getTopOffsetDrawSize() {
+    if (data.invertYAxis) {
+      return getExtraNeededVerticalSpace();
+    }
+    return super.getTopOffsetDrawSize();
   }
 
   @override


### PR DESCRIPTION
added invertYAxis property to BarChartData, LineChartData and AxisChartData --> property defaults to false

LineChartPainter / BarChartPainter overrides the getTopOffsetDrawSize method to return enough vertical space for the horizontal titles that are rendered on top when y-axis is inverted
LineChartPainter / BarChartPainter fixed content rendering when y axis is inverted

AxisChartPainter inverts most of the rendering in the getPixelY method, this is done by using the calculated y value without subtracting it from the chart height
fixed grid rendering in AxisChartPainter when y axis is inverted

i've checked my changes with your samples and it looked good so far. I hope i didn't messed up your code too much. maybe we can extract some of the calculations into methods. 