### PR TITLE
(fix) BelowBar considers its own color stops refs #46

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -267,7 +267,7 @@ class LineChartPainter extends AxisChartPainter {
           stops.add(ss * (index + 1));
         });
       } else {
-        stops = barData.colorStops;
+        stops = barData.belowBarData.gradientColorStops;
       }
 
       var from = barData.belowBarData.gradientFrom;


### PR DESCRIPTION
This fixes an issue where BelowBar ignored `gradientColorStops` property and used `colorStops` from the bar itself. Should fix #46 