### PR TITLE
Replased containerRenderBox.size to containerRenderBox.constraints.biggest

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart.dart
+++ b/lib/src/chart/bar_chart/bar_chart.dart
@@ -86,7 +86,7 @@ class BarChartState extends AnimatedWidgetBaseState<BarChart> {
       },
       child: CustomPaint(
         key: _chartKey,
-        size: getDefaultSize(context),
+        size: chartSize,
         painter: BarChartPainter(
           _withTouchedIndicators(_barChartDataTween.evaluate(animation)),
           _withTouchedIndicators(showingData),
@@ -132,7 +132,7 @@ class BarChartState extends AnimatedWidgetBaseState<BarChart> {
   Size _getChartSize() {
     if (_chartKey.currentContext != null) {
       final RenderBox containerRenderBox = _chartKey.currentContext.findRenderObject();
-      return containerRenderBox.size;
+      return containerRenderBox.constraints.biggest;
     } else {
       return getDefaultSize(context);
     }

--- a/lib/src/chart/bar_chart/bar_chart.dart
+++ b/lib/src/chart/bar_chart/bar_chart.dart
@@ -86,7 +86,7 @@ class BarChartState extends AnimatedWidgetBaseState<BarChart> {
       },
       child: CustomPaint(
         key: _chartKey,
-        size: chartSize,
+        size: getDefaultSize(context),
         painter: BarChartPainter(
           _withTouchedIndicators(_barChartDataTween.evaluate(animation)),
           _withTouchedIndicators(showingData),

--- a/lib/src/chart/line_chart/line_chart.dart
+++ b/lib/src/chart/line_chart/line_chart.dart
@@ -91,7 +91,7 @@ class LineChartState extends AnimatedWidgetBaseState<LineChart> {
       },
       child: CustomPaint(
         key: _chartKey,
-        size: chartSize,
+        size: getDefaultSize(context),
         painter: LineChartPainter(
           _withTouchedIndicators(_lineChartDataTween.evaluate(animation)),
           _withTouchedIndicators(showingData),

--- a/lib/src/chart/line_chart/line_chart.dart
+++ b/lib/src/chart/line_chart/line_chart.dart
@@ -91,7 +91,7 @@ class LineChartState extends AnimatedWidgetBaseState<LineChart> {
       },
       child: CustomPaint(
         key: _chartKey,
-        size: getDefaultSize(context),
+        size: chartSize,
         painter: LineChartPainter(
           _withTouchedIndicators(_lineChartDataTween.evaluate(animation)),
           _withTouchedIndicators(showingData),
@@ -132,7 +132,7 @@ class LineChartState extends AnimatedWidgetBaseState<LineChart> {
   Size _getChartSize() {
     if (_chartKey.currentContext != null) {
       final RenderBox containerRenderBox = _chartKey.currentContext.findRenderObject();
-      return containerRenderBox.size;
+      return containerRenderBox.constraints.biggest;
     } else {
       return getDefaultSize(context);
     }

--- a/lib/src/chart/pie_chart/pie_chart.dart
+++ b/lib/src/chart/pie_chart/pie_chart.dart
@@ -87,7 +87,7 @@ class PieChartState extends AnimatedWidgetBaseState<PieChart> {
       },
       child: CustomPaint(
         key: _chartKey,
-        size: chartSize,
+        size: getDefaultSize(context),
         painter: PieChartPainter(
           _pieChartDataTween.evaluate(animation),
           showingData,

--- a/lib/src/chart/pie_chart/pie_chart.dart
+++ b/lib/src/chart/pie_chart/pie_chart.dart
@@ -87,7 +87,7 @@ class PieChartState extends AnimatedWidgetBaseState<PieChart> {
       },
       child: CustomPaint(
         key: _chartKey,
-        size: getDefaultSize(context),
+        size: chartSize,
         painter: PieChartPainter(
           _pieChartDataTween.evaluate(animation),
           showingData,
@@ -108,7 +108,7 @@ class PieChartState extends AnimatedWidgetBaseState<PieChart> {
   Size _getChartSize() {
     if (_chartKey.currentContext != null) {
       final RenderBox containerRenderBox = _chartKey.currentContext.findRenderObject();
-      return containerRenderBox.size;
+      return containerRenderBox.constraints.biggest;
     } else {
       return getDefaultSize(context);
     }


### PR DESCRIPTION
Fix [issue 100](https://github.com/imaNNeoFighT/fl_chart/issues/100). 

RenderBox.size should not be used when building the layout. 