### PR TITLE
Gradient direction support on line chart

### DIFF
--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -189,6 +189,15 @@ class LineChartBarData {
   /// stop points of the gradient.
   final List<double> colorStops;
 
+  /// if the gradient mode is enabled (if you have more than one color)
+  /// [gradientFrom] and [gradientTo] is important otherwise they will be skipped.
+  /// you can determine where the gradient should start and end,
+  /// values are available between 0 to 1,
+  /// Offset(0, 0) represent the top / left
+  /// Offset(1, 1) represent the bottom / right
+  final Offset gradientFrom;
+  final Offset gradientTo;
+
   final double barWidth;
   final bool isCurved;
 
@@ -221,6 +230,8 @@ class LineChartBarData {
     this.show = true,
     this.colors = const [Colors.redAccent],
     this.colorStops,
+    this.gradientFrom = const Offset(0, 0),
+    this.gradientTo = const Offset(1, 0),
     this.barWidth = 2.0,
     this.isCurved = false,
     this.curveSmoothness = 0.35,
@@ -244,6 +255,8 @@ class LineChartBarData {
       dotData: FlDotData.lerp(a.dotData, b.dotData, t),
       colors: lerpColorList(a.colors, b.colors, t),
       colorStops: lerpDoubleList(a.colorStops, b.colorStops, t),
+      gradientFrom: Offset.lerp(a.gradientFrom, b.gradientFrom, t),
+      gradientTo: Offset.lerp(a.gradientTo, b.gradientTo, t),
       spots: lerpFlSpotList(a.spots, b.spots, t),
       showingIndicators: b.showingIndicators,
     );
@@ -254,6 +267,8 @@ class LineChartBarData {
     bool show,
     List<Color> colors,
     List<double> colorStops,
+    Offset gradientFrom,
+    Offset gradientTo,
     double barWidth,
     bool isCurved,
     double curveSmoothness,
@@ -269,6 +284,8 @@ class LineChartBarData {
       show: show ?? this.show,
       colors: colors ?? this.colors,
       colorStops: colorStops ?? this.colorStops,
+      gradientFrom: gradientFrom ?? this.gradientFrom,
+      gradientTo: gradientTo ?? this.gradientTo,
       barWidth: barWidth ?? this.barWidth,
       isCurved: isCurved ?? this.isCurved,
       curveSmoothness: curveSmoothness ?? this.curveSmoothness,

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -494,6 +494,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> with TouchHandler
     if (!barData.show) {
       return;
     }
+    final chartViewSize = getChartUsableDrawSize(viewSize);
 
     barPaint.strokeCap = barData.isStrokeCapRound ? StrokeCap.round : StrokeCap.butt;
 
@@ -516,14 +517,17 @@ class LineChartPainter extends AxisChartPainter<LineChartData> with TouchHandler
         stops = barData.colorStops;
       }
 
+      final from = barData.gradientFrom;
+      final to = barData.gradientTo;
+
       barPaint.shader = ui.Gradient.linear(
         Offset(
-          getLeftOffsetDrawSize(),
-          getTopOffsetDrawSize() + (viewSize.height / 2),
+          getLeftOffsetDrawSize() + (chartViewSize.width * from.dx),
+          getTopOffsetDrawSize() + (chartViewSize.height * from.dy),
         ),
         Offset(
-          getLeftOffsetDrawSize() + viewSize.width,
-          getTopOffsetDrawSize() + (viewSize.height / 2),
+          getLeftOffsetDrawSize() + (chartViewSize.width * to.dx),
+          getTopOffsetDrawSize() + (chartViewSize.height * to.dy),
         ),
         barData.colors,
         stops,

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -36,6 +36,8 @@ LineChart(
 |spots| list of [FlSpot](base_chart.md#FlSpot)'s x and y coordinates that the line go through it| []
 |colors| colors the line, if multiple colors provided it will be gradient|[Colors.redAccent]|
 |colorStops| gets the stop positions of the gradient color, [Read More](https://api.flutter.dev/flutter/dart-ui/Gradient/Gradient.linear.html)|null|
+|gradientFrom|determines start of the gradient, each number should be between 0 and 1, [Read More](https://api.flutter.dev/flutter/dart-ui/Gradient/Gradient.linear.html)|Offset(0, 0)|
+|gradientTo|determines end of the gradient, each number should be between 0 and 1, [Read More](https://api.flutter.dev/flutter/dart-ui/Gradient/Gradient.linear.html)|Offset(1, 0)|
 |barWidth| gets the stroke width of the line bar|2.0|
 |isCurved| curves the corners of the line on the spot's positions| false|
 |curveSmoothness| smoothness radius of the curve corners (works when isCurved is true) | 0.35|


### PR DESCRIPTION
I needed a way to show low and high values on the chart so I modified `LineChartBarData` implementation to support `gradientFrom` and `gradientTo` parameters based on similar logic from `BarAreaData` implementation.
With those changes making charts like the one in attachment is possible.

![Screenshot_1574536012](https://user-images.githubusercontent.com/83073/69483920-70fa7200-0e2d-11ea-8c13-9a4597bacef8.png)
![Simulator Screen Shot - iPhone 11 - 2019-11-24 at 12 47 27](https://user-images.githubusercontent.com/83073/69494598-f2014a00-0ebd-11ea-9f43-7f06657f3b98.png)