### PR TITLE
respect text scale factor when drawing text

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart.dart
+++ b/lib/src/chart/bar_chart/bar_chart.dart
@@ -129,6 +129,7 @@ class BarChartState extends AnimatedWidgetBaseState<BarChart> {
               _touchHandler = touchHandler;
             });
           },
+          textScale: MediaQuery.of(context).textScaleFactor,
         ),
       ),
     );

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -16,8 +16,9 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
   BarChartPainter(
     BarChartData data,
     BarChartData targetData,
-    Function(TouchHandler) touchHandler,
-  ) : super(data, targetData) {
+      Function(TouchHandler) touchHandler,
+      {double textScale = 1})
+      : super(data, targetData, textScale: textScale) {
     touchHandler(this);
     barPaint = Paint()..style = PaintingStyle.fill;
 
@@ -286,8 +287,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
         final String text = leftTitles.getTitles(verticalSeek);
 
         final TextSpan span = TextSpan(style: leftTitles.textStyle, text: text);
-        final TextPainter tp =
-        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+        final TextPainter tp = TextPainter(
+            text: span,
+            textAlign: TextAlign.center,
+            textDirection: TextDirection.ltr,
+            textScaleFactor: textScale);
         tp.layout(maxWidth: getExtraNeededHorizontalSpace());
         x -= tp.width + leftTitles.margin;
         y -= tp.height / 2;
@@ -314,8 +318,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
         final String text = rightTitles.getTitles(verticalSeek);
 
         final TextSpan span = TextSpan(style: rightTitles.textStyle, text: text);
-        final TextPainter tp =
-        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+        final TextPainter tp = TextPainter(
+            text: span,
+            textAlign: TextAlign.center,
+            textDirection: TextDirection.ltr,
+            textScaleFactor: textScale);
         tp.layout(maxWidth: getExtraNeededHorizontalSpace());
         x += rightTitles.margin;
         y -= tp.height / 2;
@@ -339,8 +346,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
 
         final String text = bottomTitles.getTitles(index.toDouble());
         final TextSpan span = TextSpan(style: bottomTitles.textStyle, text: text);
-        final TextPainter tp =
-            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+        final TextPainter tp = TextPainter(
+            text: span,
+            textAlign: TextAlign.center,
+            textDirection: TextDirection.ltr,
+            textScaleFactor: textScale);
         tp.layout();
         double x = groupBarPos.groupX;
         double y = drawSize.height + getTopOffsetDrawSize() + bottomTitles.margin;
@@ -376,8 +386,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
     }
 
     final TextSpan span = TextSpan(style: tooltipItem.textStyle, text: tooltipItem.text);
-    final TextPainter tp =
-    TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+    final TextPainter tp = TextPainter(
+        text: span,
+        textAlign: TextAlign.center,
+        textDirection: TextDirection.ltr,
+        textScaleFactor: textScale);
     tp.layout(maxWidth: tooltipData.maxContentWidth);
 
     /// creating TextPainters to calculate the width and height of the tooltip

--- a/lib/src/chart/base/axis_chart/axis_chart_painter.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_painter.dart
@@ -15,8 +15,8 @@ import 'axis_chart_data.dart';
 abstract class AxisChartPainter<D extends AxisChartData> extends BaseChartPainter<D> {
   Paint gridPaint, backgroundPaint;
 
-  AxisChartPainter(D data, D targetData,)
-      : super(data, targetData,) {
+  AxisChartPainter(D data, D targetData, {double textScale})
+      : super(data, targetData, textScale: textScale) {
     gridPaint = Paint()..style = PaintingStyle.fill;
 
     backgroundPaint = Paint()..style = PaintingStyle.fill;
@@ -47,7 +47,8 @@ abstract class AxisChartPainter<D extends AxisChartData> extends BaseChartPainte
       final TextPainter tp = TextPainter(
           text: span,
           textAlign: leftTitle.textAlign,
-          textDirection: TextDirection.ltr);
+          textDirection: TextDirection.ltr,
+          textScaleFactor: textScale);
       tp.layout(minWidth: viewSize.height);
       canvas.save();
       canvas.rotate(-math.pi * 0.5);
@@ -66,7 +67,8 @@ abstract class AxisChartPainter<D extends AxisChartData> extends BaseChartPainte
       final TextPainter tp = TextPainter(
           text: span,
           textAlign: topTitle.textAlign,
-          textDirection: TextDirection.ltr);
+          textDirection: TextDirection.ltr,
+          textScaleFactor: textScale);
       tp.layout(minWidth: viewSize.width);
       tp.paint(canvas,
           Offset(getLeftOffsetDrawSize(), topTitle.reservedSize - tp.height));
@@ -80,7 +82,8 @@ abstract class AxisChartPainter<D extends AxisChartData> extends BaseChartPainte
       final TextPainter tp = TextPainter(
           text: span,
           textAlign: rightTitle.textAlign,
-          textDirection: TextDirection.ltr);
+          textDirection: TextDirection.ltr,
+          textScaleFactor: textScale);
       tp.layout(minWidth: viewSize.height);
       canvas.save();
       canvas.rotate(-math.pi * 0.5);
@@ -102,7 +105,8 @@ abstract class AxisChartPainter<D extends AxisChartData> extends BaseChartPainte
       final TextPainter tp = TextPainter(
           text: span,
           textAlign: bottomTitle.textAlign,
-          textDirection: TextDirection.ltr);
+          textDirection: TextDirection.ltr,
+          textScaleFactor: textScale);
       tp.layout(minWidth: viewSize.width);
       tp.paint(
           canvas,

--- a/lib/src/chart/base/base_chart/base_chart_painter.dart
+++ b/lib/src/chart/base/base_chart/base_chart_painter.dart
@@ -18,9 +18,10 @@ abstract class BaseChartPainter<D extends BaseChartData> extends CustomPainter {
   final D data;
   final D targetData;
   Paint borderPaint;
+  double textScale;
 
-  BaseChartPainter(this.data, this.targetData)
-    : super() {
+  BaseChartPainter(this.data, this.targetData, {this.textScale = 1})
+      : super() {
     borderPaint = Paint()
       ..style = PaintingStyle.stroke;
   }

--- a/lib/src/chart/line_chart/line_chart.dart
+++ b/lib/src/chart/line_chart/line_chart.dart
@@ -127,14 +127,13 @@ class LineChartState extends AnimatedWidgetBaseState<LineChart> {
         key: _chartKey,
         size: getDefaultSize(context),
         painter: LineChartPainter(
-          _withTouchedIndicators(_lineChartDataTween.evaluate(animation)),
-          _withTouchedIndicators(showingData),
-          (touchHandler) {
-            setState(() {
-              _touchHandler = touchHandler;
-            });
-          },
-        ),
+            _withTouchedIndicators(_lineChartDataTween.evaluate(animation)),
+            _withTouchedIndicators(showingData),
+            (touchHandler) {
+          setState(() {
+            _touchHandler = touchHandler;
+          });
+        }, textScale: MediaQuery.of(context).textScaleFactor),
       ),
     );
   }

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -34,7 +34,8 @@ class LineChartPainter extends AxisChartPainter<LineChartData> with TouchHandler
     LineChartData data,
     LineChartData targetData,
     Function(TouchHandler) touchHandler,
-  ) : super(data, targetData,) {
+    {double textScale})
+    : super(data, targetData, textScale: textScale) {
     touchHandler(this);
     
     barPaint = Paint()..style = PaintingStyle.stroke;
@@ -648,7 +649,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> with TouchHandler
 
         final TextSpan span = TextSpan(style: leftTitles.textStyle, text: text);
         final TextPainter tp =
-            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout(maxWidth: getExtraNeededHorizontalSpace());
         x -= tp.width + leftTitles.margin;
         y -= tp.height / 2;
@@ -676,7 +677,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> with TouchHandler
 
         final TextSpan span = TextSpan(style: topTitles.textStyle, text: text);
         final TextPainter tp =
-            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout();
 
         x -= tp.width / 2;
@@ -705,7 +706,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> with TouchHandler
 
         final TextSpan span = TextSpan(style: rightTitles.textStyle, text: text);
         final TextPainter tp =
-            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout(maxWidth: getExtraNeededHorizontalSpace());
 
         x += rightTitles.margin;
@@ -732,7 +733,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> with TouchHandler
         final String text = bottomTitles.getTitles(horizontalSeek);
         final TextSpan span = TextSpan(style: bottomTitles.textStyle, text: text);
         final TextPainter tp =
-            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout();
 
         x -= tp.width / 2;
@@ -813,7 +814,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> with TouchHandler
 
       final TextSpan span = TextSpan(style: tooltipItem.textStyle, text: tooltipItem.text);
       final TextPainter tp =
-      TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+      TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
       tp.layout(maxWidth: tooltipData.maxContentWidth);
       drawingTextPainters.add(tp);
     }

--- a/lib/src/chart/pie_chart/pie_chart.dart
+++ b/lib/src/chart/pie_chart/pie_chart.dart
@@ -129,6 +129,7 @@ class PieChartState extends AnimatedWidgetBaseState<PieChart> {
               _touchHandler = touchHandler;
             });
           },
+          textScale: MediaQuery.of(context).textScaleFactor,
         ),
       ),
     );

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -23,7 +23,8 @@ class PieChartPainter extends BaseChartPainter<PieChartData> with TouchHandler<P
     PieChartData data,
     PieChartData targetData,
     Function(TouchHandler) touchHandler,
-  ) : super(data, targetData,) {
+    {double textScale}
+  ) : super(data, targetData, textScale: textScale) {
     touchHandler(this);
 
     sectionPaint = Paint()..style = PaintingStyle.stroke;
@@ -156,7 +157,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> with TouchHandler<P
       if (section.showTitle) {
         final TextSpan span = TextSpan(style: section.titleStyle, text: section.title);
         final TextPainter tp =
-            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+            TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout();
         tp.paint(canvas, sectionCenterOffset - Offset(tp.width / 2, tp.height / 2));
       }

--- a/lib/src/chart/scatter_chart/scatter_chart.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart.dart
@@ -130,6 +130,7 @@ class ScatterChartState extends AnimatedWidgetBaseState<ScatterChart> {
               _touchHandler = touchHandler;
             });
           },
+          textScale: MediaQuery.of(context).textScaleFactor,
         ),
       ),
     );

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -17,7 +17,8 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> with TouchH
     ScatterChartData data,
     ScatterChartData targetData,
     Function(TouchHandler) touchHandler,
-    ) : super(data, targetData,) {
+    {double textScale}
+    ) : super(data, targetData, textScale: textScale) {
     touchHandler(this);
 
     spotsPaint = Paint()..style = PaintingStyle.fill;
@@ -64,7 +65,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> with TouchH
 
         final TextSpan span = TextSpan(style: leftTitles.textStyle, text: text);
         final TextPainter tp =
-        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout(maxWidth: getExtraNeededHorizontalSpace());
         x -= tp.width + leftTitles.margin;
         y -= tp.height / 2;
@@ -92,7 +93,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> with TouchH
 
         final TextSpan span = TextSpan(style: topTitles.textStyle, text: text);
         final TextPainter tp =
-        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout();
 
         x -= tp.width / 2;
@@ -121,7 +122,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> with TouchH
 
         final TextSpan span = TextSpan(style: rightTitles.textStyle, text: text);
         final TextPainter tp =
-        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout(maxWidth: getExtraNeededHorizontalSpace());
 
         x += rightTitles.margin;
@@ -150,7 +151,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> with TouchH
 
         final TextSpan span = TextSpan(style: bottomTitles.textStyle, text: text);
         final TextPainter tp =
-        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+        TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
         tp.layout();
 
         x -= tp.width / 2;
@@ -200,7 +201,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> with TouchH
 
     final TextSpan span = TextSpan(style: tooltipItem.textStyle, text: tooltipItem.text);
     final TextPainter drawingTextPainter =
-    TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr);
+    TextPainter(text: span, textAlign: TextAlign.center, textDirection: TextDirection.ltr, textScaleFactor: textScale);
     drawingTextPainter.layout(maxWidth: tooltipData.maxContentWidth);
 
     final width = drawingTextPainter.width;


### PR DESCRIPTION
All painters should use the text scale factor when drawing text. Since there is no context in the chart painters available, we have to inject it during the creation of each painter.