### PR TITLE
Feature: full height touchline

### DIFF
--- a/example/lib/line_chart/samples/line_chart_sample8.dart
+++ b/example/lib/line_chart/samples/line_chart_sample8.dart
@@ -96,6 +96,7 @@ class _LineChartSample8State extends State<LineChartSample8> {
         ),
       ),
       lineTouchData: LineTouchData(
+        fullHeightTouchLine: true,
         getTouchedSpotIndicator: (LineChartBarData barData, List<int> spotIndexes) {
           return spotIndexes.map((spotIndex) {
             final FlSpot spot = barData.spots[spotIndex];

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -618,6 +618,9 @@ class LineTouchData extends FlTouchData {
   /// (show a tooltip bubble and an indicator on touched spots)
   final bool handleBuiltInTouches;
 
+  /// if you want the touchline to reach the top of the chart
+  final bool fullHeightTouchLine;
+
   /// you can implement it to receive touches callback
   final Function(LineTouchResponse) touchCallback;
 
@@ -627,6 +630,7 @@ class LineTouchData extends FlTouchData {
     this.touchTooltipData = const LineTouchTooltipData(),
     this.getTouchedSpotIndicator = defaultTouchedIndicators,
     this.touchSpotThreshold = 10,
+    this.fullHeightTouchLine = false,
     this.handleBuiltInTouches = true,
     this.touchCallback,
   }) : super(enabled, enableNormalTouch);
@@ -634,6 +638,7 @@ class LineTouchData extends FlTouchData {
   LineTouchData copyWith({
     bool enabled,
     bool enableNormalTouch,
+    bool fullHeightTouchLine,
     LineTouchTooltipData touchTooltipData,
     GetTouchedSpotIndicator getTouchedSpotIndicator,
     double touchSpotThreshold,
@@ -642,6 +647,7 @@ class LineTouchData extends FlTouchData {
     return LineTouchData(
       enabled: enabled ?? this.enabled,
       enableNormalTouch: enableNormalTouch ?? this.enableNormalTouch,
+      fullHeightTouchLine: fullHeightTouchLine ?? this.fullHeightTouchLine,
       touchTooltipData: touchTooltipData ?? this.touchTooltipData,
       getTouchedSpotIndicator: getTouchedSpotIndicator ?? this.getTouchedSpotIndicator,
       touchSpotThreshold: touchSpotThreshold ?? this.touchSpotThreshold,

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -205,23 +205,28 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
         continue;
       }
 
+      /// For drawing the dot
       final Offset touchedSpot =
           Offset(getPixelX(spot.x, chartViewSize), getPixelY(spot.y, chartViewSize));
 
-      /// Draw the indicator line
+      /// For drawing the indicator line
       final from = Offset(touchedSpot.dx, getTopOffsetDrawSize() + chartViewSize.height);
-      final to = touchedSpot;
+      final top = Offset(getPixelX(spot.x, chartViewSize), getTopOffsetDrawSize());
+
+      /// Draw to top or to the touchedSpot
+      final Offset lineEnd = data.lineTouchData.fullHeightTouchLine ? top : touchedSpot;
 
       touchLinePaint.color = indicatorData.indicatorBelowLine.color;
       touchLinePaint.strokeWidth = indicatorData.indicatorBelowLine.strokeWidth;
 
-      canvas.drawDashedLine(from, to, touchLinePaint, indicatorData.indicatorBelowLine.dashArray);
+      canvas.drawDashedLine(
+          from, lineEnd, touchLinePaint, indicatorData.indicatorBelowLine.dashArray);
 
       /// Draw the indicator dot
       if (indicatorData.touchedSpotDotData != null && indicatorData.touchedSpotDotData.show) {
         final double selectedSpotDotSize = indicatorData.touchedSpotDotData.dotSize;
         dotPaint.color = indicatorData.touchedSpotDotData.dotColor;
-        canvas.drawCircle(to, selectedSpotDotSize, dotPaint);
+        canvas.drawCircle(touchedSpot, selectedSpotDotSize, dotPaint);
       }
     }
   }


### PR DESCRIPTION
This is an addition to the touchline. Setting the bool to `true` will stop it at the top of the chart instead of at the dot.

![image](https://user-images.githubusercontent.com/3495974/75295108-9f526980-57ef-11ea-9c30-bcc5b127b281.png)
