### PR TITLE
Fix for fitInsideTheChart when tooltip is below or above the chart area

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -973,6 +973,23 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
             rect.bottom,
           );
       }
+
+      if (rect.top < 0) {
+        rect = Rect.fromLTRB(rect.left,
+          0,
+          rect.right,
+          tooltipHeight,
+        );
+      }
+
+      if (rect.bottom > viewSize.height) {
+        final shiftAmount = rect.bottom - viewSize.height + tooltipHeight;
+        rect = Rect.fromLTRB(rect.left,
+          rect.top - shiftAmount,
+          rect.right,
+          rect.bottom - shiftAmount,
+        );
+      }
     }
 
     final Radius radius = Radius.circular(tooltipData.tooltipRoundedRadius);


### PR DESCRIPTION
Fixes situation where the tooltip, having set fitInsideTheChart, goes above or below the chart area.

Was:
![was](https://user-images.githubusercontent.com/4688431/76558724-1ea59580-649e-11ea-9412-dfb103e97de9.png)
Is:
![is](https://user-images.githubusercontent.com/4688431/76558732-21a08600-649e-11ea-8ee6-e59647e816ae.png)
