### PR TITLE
Added fitInsideVertically support for bar chart and line chart tooltips

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -375,7 +375,8 @@ class BarTouchTooltipData {
   final double tooltipBottomMargin;
   final double maxContentWidth;
   final GetBarTooltipItem getTooltipItem;
-  final bool fitInsideTheChart;
+  final bool fitInsideHorizontally;
+  final bool fitInsideVertically;
 
   const BarTouchTooltipData({
     this.tooltipBgColor = Colors.white,
@@ -384,7 +385,8 @@ class BarTouchTooltipData {
     this.tooltipBottomMargin = 16,
     this.maxContentWidth = 120,
     this.getTooltipItem = defaultBarTooltipItem,
-    this.fitInsideTheChart = false,
+    this.fitInsideHorizontally = false,
+    this.fitInsideVertically = false,
   }) : super();
 }
 

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -401,7 +401,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
         tooltipWidth,
         tooltipHeight);
 
-    if (tooltipData.fitInsideTheChart) {
+    if (tooltipData.fitInsideHorizontally) {
       if (rect.left < 0) {
         final shiftAmount = 0 - rect.left;
         rect = Rect.fromLTRB(
@@ -419,6 +419,28 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
           rect.top,
           rect.right - shiftAmount,
           rect.bottom,
+        );
+      }
+    }
+
+    if (tooltipData.fitInsideVertically) {
+      if (rect.top < 0) {
+        final shiftAmount = 0 - rect.top;
+        rect = Rect.fromLTRB(
+          rect.left,
+          rect.top + shiftAmount,
+          rect.right,
+          rect.bottom + shiftAmount,
+        );
+      }
+
+      if (rect.bottom > viewSize.height) {
+        final shiftAmount = rect.bottom - viewSize.height;
+        rect = Rect.fromLTRB(
+          rect.left,
+          rect.top - shiftAmount,
+          rect.right,
+          rect.bottom - shiftAmount,
         );
       }
     }

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -717,7 +717,8 @@ class LineTouchTooltipData {
   final double tooltipBottomMargin;
   final double maxContentWidth;
   final GetLineTooltipItems getTooltipItems;
-  final bool fitInsideTheChart;
+  final bool fitInsideHorizontally;
+  final bool fitInsideVertically;
 
   const LineTouchTooltipData({
     this.tooltipBgColor = Colors.white,
@@ -726,7 +727,8 @@ class LineTouchTooltipData {
     this.tooltipBottomMargin = 16,
     this.maxContentWidth = 120,
     this.getTooltipItems = defaultLineTooltipItem,
-    this.fitInsideTheChart = false,
+    this.fitInsideHorizontally = false,
+    this.fitInsideVertically = false,
   }) : super();
 }
 

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -989,7 +989,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
         tooltipWidth,
         tooltipHeight);
 
-    if (tooltipData.fitInsideTheChart) {
+    if (tooltipData.fitInsideHorizontally) {
       if (rect.left < 0) {
         final shiftAmount = 0 - rect.left;
         rect = Rect.fromLTRB(
@@ -1009,18 +1009,23 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
           rect.bottom,
         );
       }
+    }
 
+    if (tooltipData.fitInsideVertically) {
       if (rect.top < 0) {
-        rect = Rect.fromLTRB(rect.left,
-          0,
+        final shiftAmount = 0 - rect.top;
+        rect = Rect.fromLTRB(
+          rect.left,
+          rect.top + shiftAmount,
           rect.right,
-          tooltipHeight,
+          rect.bottom + shiftAmount,
         );
       }
 
       if (rect.bottom > viewSize.height) {
-        final shiftAmount = rect.bottom - viewSize.height + tooltipHeight;
-        rect = Rect.fromLTRB(rect.left,
+        final shiftAmount = rect.bottom - viewSize.height;
+        rect = Rect.fromLTRB(
+          rect.left,
           rect.top - shiftAmount,
           rect.right,
           rect.bottom - shiftAmount,

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -84,7 +84,8 @@ enum values {`start`, `end`, `center`, `spaceEvenly`, `spaceAround`, `spaceBetwe
  |tooltipBottomMargin|bottom margin of the tooltip (to the top of most top spot)|16|
  |maxContentWidth|maximum width of the tooltip (if a text row is wider than this, then the text breaks to a new line|120|
  |getTooltipItems|a callback that retrieve [BarTooltipItem](#BarTooltipItem) by the given [BarChartGroupData](#BarChartGroupData), groupIndex, [BarChartRodData](#BarChartRodData) and rodIndex |defaultBarTooltipItem|
- |fitInsideTheChart| forces tooltip to shift inside the chart's bounding box| false|
+ |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
+ |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
 
 ### BarTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -168,7 +168,8 @@ LineChart(
  |tooltipBottomMargin|bottom margin of the tooltip (to the top of most top spot)|16|
  |maxContentWidth|maximum width of the tooltip (if a text row is wider than this, then the text breaks to a new line|120|
  |getTooltipItems|a callback that retrieve list of [LineTooltipItem](#LineTooltipItem) by the given list of [LineBarSpot](#LineBarSpot) |defaultLineTooltipItem|
- |fitInsideTheChart| forces tooltip to shift inside the chart's bounding box| false|
+ |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
+ |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
 
 ### LineTooltipItem
 |PropName|Description|default value|


### PR DESCRIPTION
This is a copy of PR #237 for the dev branch
This PR provides a fix for #225 

Changes added -

1. Added new parameter fitInsideVertically to BarTouchTooltipData and LineTouchTooltipData for fitting the tooltip vertically inside the charts.
2. Renamed fitInsideTheChart to fitInsideHorizontally to avoid confusion.
3. Updated documentation.