### PR TITLE
Replace pan gesture with horizontal drag & tap combination

### DIFF
--- a/lib/src/chart/base/base_chart/touch_input.dart
+++ b/lib/src/chart/base/base_chart/touch_input.dart
@@ -5,10 +5,8 @@ import 'package:flutter/material.dart';
 /// Each touch gesture should be contained an offset,
 /// that determines the touch location in the screen.
 abstract class FlTouchInput {
-
   /// Determines the touch location in the screen.
   Offset getOffset();
-
 }
 
 /// Abstract class for long touches input
@@ -16,7 +14,6 @@ abstract class FlTouchLongInput extends FlTouchInput {}
 
 /// Represents a [GestureDetector.onLongPressStart] event.
 class FlLongPressStart extends FlTouchLongInput {
-
   /// It is a localized touch position inside our widget,
   /// it represents [LongPressStartDetails.localPosition].
   final Offset localPosition;
@@ -31,12 +28,10 @@ class FlLongPressStart extends FlTouchLongInput {
   Offset getOffset() {
     return localPosition;
   }
-
 }
 
 /// Represents a [GestureDetector.onLongPressMoveUpdate] event.
 class FlLongPressMoveUpdate extends FlTouchLongInput {
-
   /// It is a localized touch position inside our widget,
   /// it represents [LongPressMoveUpdateDetails.localPosition].
   final Offset localPosition;
@@ -51,12 +46,10 @@ class FlLongPressMoveUpdate extends FlTouchLongInput {
   Offset getOffset() {
     return localPosition;
   }
-
 }
 
 /// Represents a [GestureDetector.onLongPressEnd] event.
 class FlLongPressEnd extends FlTouchLongInput {
-
   /// It is a localized touch position inside our widget,
   /// it represents [LongPressEndDetails.localPosition].
   final Offset localPosition;
@@ -78,7 +71,6 @@ abstract class FlTouchNormalInput extends FlTouchInput {}
 
 /// Represents a [GestureDetector.onPanDown] event.
 class FlPanStart extends FlTouchNormalInput {
-
   /// It is a localized touch position inside our widget,
   /// it represents [DragDownDetails.localPosition].
   final Offset localPosition;
@@ -93,12 +85,25 @@ class FlPanStart extends FlTouchNormalInput {
   Offset getOffset() {
     return localPosition;
   }
+}
 
+/// Convenience class for a simple tap to use for conditionals
+/// used for [GestureDetector.onTapCancel] and [GestureDetector.onTapUp]
+class FlTap extends FlTouchNormalInput {
+  /// It is a localized touch position inside our widget,
+  /// it represents [TapDownDetails.localPosition].
+  final Offset localPosition;
+
+  FlTap(this.localPosition);
+
+  @override
+  Offset getOffset() {
+    return localPosition;
+  }
 }
 
 /// Represents a [GestureDetector.onPanUpdate] event.
 class FlPanMoveUpdate extends FlTouchNormalInput {
-
   /// It is a localized touch position inside our widget,
   /// it represents [DragUpdateDetails.localPosition].
   final Offset localPosition;
@@ -117,7 +122,6 @@ class FlPanMoveUpdate extends FlTouchNormalInput {
 
 /// Represents a [GestureDetector.onPanEnd] event.
 class FlPanEnd extends FlTouchNormalInput {
-
   /// It is a localized touch position inside our widget.
   final Offset localPosition;
 
@@ -136,5 +140,4 @@ class FlPanEnd extends FlTouchNormalInput {
   Offset getOffset() {
     return localPosition;
   }
-
 }

--- a/lib/src/chart/line_chart/line_chart.dart
+++ b/lib/src/chart/line_chart/line_chart.dart
@@ -9,7 +9,6 @@ import 'line_chart_painter.dart';
 
 /// Renders a line chart as a widget, using provided [LineChartData].
 class LineChart extends ImplicitlyAnimatedWidget {
-
   /// Determines how the [LineChart] should be look like.
   final LineChartData data;
 
@@ -24,7 +23,6 @@ class LineChart extends ImplicitlyAnimatedWidget {
   /// Creates a [_LineChartState]
   @override
   _LineChartState createState() => _LineChartState();
-
 }
 
 class _LineChartState extends AnimatedWidgetBaseState<LineChart> {
@@ -39,6 +37,9 @@ class _LineChartState extends AnimatedWidgetBaseState<LineChart> {
   final List<MapEntry<int, List<LineBarSpot>>> _showingTouchedTooltips = [];
 
   final Map<int, List<int>> _showingTouchedIndicators = {};
+
+  // to set the correct ending position of a gesture
+  Offset _lastTouchedPosition;
 
   @override
   Widget build(BuildContext context) {
@@ -82,31 +83,44 @@ class _LineChartState extends AnimatedWidgetBaseState<LineChart> {
           touchData.touchCallback(response);
         }
       },
-      onPanCancel: () {
-        final Size chartSize = _getChartSize();
-        if (chartSize == null) {
-          return;
-        }
-
-        final LineTouchResponse response = _touchHandler?.handleTouch(
-            FlPanEnd(Offset.zero, Velocity(pixelsPerSecond: Offset.zero)), chartSize);
-        if (_canHandleTouch(response, touchData)) {
-          touchData.touchCallback(response);
-        }
-      },
-      onPanEnd: (DragEndDetails details) {
+      onTapCancel: () {
         final Size chartSize = _getChartSize();
         if (chartSize == null) {
           return;
         }
 
         final LineTouchResponse response =
-            _touchHandler?.handleTouch(FlPanEnd(Offset.zero, details.velocity), chartSize);
+            _touchHandler?.handleTouch(FlTap(_lastTouchedPosition), chartSize);
         if (_canHandleTouch(response, touchData)) {
           touchData.touchCallback(response);
         }
       },
-      onPanDown: (DragDownDetails details) {
+      onTapDown: (details) {
+        final Size chartSize = _getChartSize();
+        if (chartSize == null) {
+          return;
+        }
+
+        final LineTouchResponse response =
+            _touchHandler?.handleTouch(FlPanStart(details.localPosition), chartSize);
+        if (_canHandleTouch(response, touchData)) {
+          _lastTouchedPosition = details.localPosition;
+          touchData.touchCallback(response);
+        }
+      },
+      onTapUp: (details) {
+        final Size chartSize = _getChartSize();
+        if (chartSize == null) {
+          return;
+        }
+
+        final LineTouchResponse response =
+            _touchHandler?.handleTouch(FlTap(details.localPosition), chartSize);
+        if (_canHandleTouch(response, touchData)) {
+          touchData.touchCallback(response);
+        }
+      },
+      onHorizontalDragStart: (DragStartDetails details) {
         final Size chartSize = _getChartSize();
         if (chartSize == null) {
           return;
@@ -118,7 +132,7 @@ class _LineChartState extends AnimatedWidgetBaseState<LineChart> {
           touchData.touchCallback(response);
         }
       },
-      onPanUpdate: (DragUpdateDetails details) {
+      onHorizontalDragUpdate: (DragUpdateDetails details) {
         final Size chartSize = _getChartSize();
         if (chartSize == null) {
           return;
@@ -126,6 +140,19 @@ class _LineChartState extends AnimatedWidgetBaseState<LineChart> {
 
         final LineTouchResponse response =
             _touchHandler?.handleTouch(FlPanMoveUpdate(details.localPosition), chartSize);
+        if (_canHandleTouch(response, touchData)) {
+          _lastTouchedPosition = details.localPosition;
+          touchData.touchCallback(response);
+        }
+      },
+      onHorizontalDragEnd: (DragEndDetails details) {
+        final Size chartSize = _getChartSize();
+        if (chartSize == null) {
+          return;
+        }
+
+        final LineTouchResponse response =
+            _touchHandler?.handleTouch(FlPanEnd(_lastTouchedPosition, details.velocity), chartSize);
         if (_canHandleTouch(response, touchData)) {
           touchData.touchCallback(response);
         }


### PR DESCRIPTION
The previous "Pan" gesture was causing problems on scroll views where a quick swipe up would trigger a touch response inside of a chart. It has been replaced with a combination of horizontal drag and tap. The tap is only there so that the first swiped point is shown, which triggers a tapCancel. It's a little complicated but it works correctly to replace pan. I reused some of the old pan constructors for simplicity and backward compatibility. 

Furthermore, I used setState to get the localPosition from the gesture update in order to properly provide the final updated position to the end of the gesture. 

Fixes #265, #227 , #210, #202. 
Also if we pass the tapped line in the LineChart, this #73, gonna be fixed. 
It should be checked #276.