### PR TITLE
Fix code blocks highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ dependencies:
 ### 2 - Install it
 
 ##### Install packages from the command line
-```yml
+```sh
 flutter packages get
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Thank you all!
 
 ##### Add it to your package's pubspec.yaml file
 
-```kotlin
+```yml
 dependencies:
   fl_chart: ^0.8.1
 ```
@@ -48,7 +48,7 @@ dependencies:
 ### 2 - Install it
 
 ##### Install packages from the command line
-```kotlin
+```yml
 flutter packages get
 ```
 

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/bar_chart/bar_chart.jpg" width="300" >
 
 ### How to use
-```
+```dart
 BarChart(
   BarChartData(
     // read about it in the below section

--- a/repo_files/documentations/handle_animations.md
+++ b/repo_files/documentations/handle_animations.md
@@ -9,7 +9,7 @@ We handle all animations Implicitly, This is power of the [ImplicitlyAnimatedWid
 
 ##### Duration
 we added an optional argument in the `FlChart` class called  `swapAnimationDuration`, this is a [Duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) class that you can set the duration of the animation. the default value is `150 ms`, you can change it to fit your requirements.
-```
+```dart
 LineChart(
   swapAnimationDuration: Duration(milliseconds: 150),
   LineChartData(

--- a/repo_files/documentations/handle_touches.md
+++ b/repo_files/documentations/handle_touches.md
@@ -15,7 +15,7 @@ If you set `handleBuiltInTouches` true, it will handle touch by showing a toolti
 #### How to use? (for example in `LineChart`)
 ##### In the Line and Bar Charts we show a built in tooltip on the touched spots, then you just need to config how to show it, just fill the `touchTooltipData` in the `LineTouchData`.
 #####
-```
+```dart
 LineChart(
   LineChartData(
     lineTouchData: LineTouchData(
@@ -30,7 +30,7 @@ LineChart(
 )
 ```
 ##### But if you want more customization on touch behaviors, implement the `touchCallback` and handle it.
-```
+```dart
 
 LineChart(
   LineChartData(

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/line_chart/line_chart.jpg" width="300" >
 
 ### How to use
-```
+```dart
 LineChart(
   LineChartData(
     // read about it in the below section

--- a/repo_files/documentations/pie_chart.md
+++ b/repo_files/documentations/pie_chart.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/pie_chart/pie_chart.jpg" width="300" >
 
 ### How to use
-```
+```dart
 PieChart(
   PieChartData(
     // read about it in the below section

--- a/repo_files/documentations/scatter_chart.md
+++ b/repo_files/documentations/scatter_chart.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/scatter_chart/scatter_chart.png" width="300" >
 
 ### How to use
-```
+```dart
 ScatterChart(
   ScatterChartData(
     // read about it in the below section


### PR DESCRIPTION
The code blocks are now highlighted correctly, whereas before there was no syntax highlighting or wrong syntax highlighting.