### PR TITLE
Adding barData parameter to checkToShowDot Function

### DIFF
--- a/example/lib/line_chart/samples/line_chart_sample3.dart
+++ b/example/lib/line_chart/samples/line_chart_sample3.dart
@@ -129,7 +129,7 @@ class LineChartSample3 extends StatelessWidget {
                       dotSize: 6,
                       strokeWidth: 4,
                       getStrokeColor: (spot, percent, barData) => Colors.deepOrange,
-                      checkToShowDot: (spot) {
+                      checkToShowDot: (spot, barData) {
                         return spot.x != 0 && spot.x != 6;
                       }),
                 ),

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -794,10 +794,10 @@ class FlDotData with EquatableMixin {
 ///
 /// It gives you the checking [FlSpot] and you should decide to
 /// show or hide the dot on this spot by returning true or false.
-typedef CheckToShowDot = bool Function(FlSpot spot);
+typedef CheckToShowDot = bool Function(FlSpot spot, LineChartBarData barData);
 
 /// Shows all dots on spots.
-bool showAllDots(FlSpot spot) {
+bool showAllDots(FlSpot spot, LineChartBarData barData) {
   return true;
 }
 

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -236,7 +236,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
 
     for (int i = 0; i < barData.spots.length; i++) {
       final FlSpot spot = barData.spots[i];
-      if (barData.dotData.checkToShowDot(spot)) {
+      if (barData.dotData.checkToShowDot(spot, barData)) {
         final double x = getPixelX(spot.x, viewSize);
         final double y = getPixelY(spot.y, viewSize);
 

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -459,7 +459,7 @@ final BarAreaData barAreaData4 = BarAreaData(
 );
 
 final Function(FlSpot, double, LineChartBarData) getDotColor = (spot, percent, bar) => Colors.green;
-final Function(FlSpot spot) checkToShowDot = (spot) => true;
+final Function(FlSpot spot, LineChartBarData barData) checkToShowDot = (spot, barData) => true;
 
 final FlDotData flDotData1 = FlDotData(
   show: true,


### PR DESCRIPTION
Like the GetDotColorCallback that contains the barData parameter, it's usefull to pass it also to the checkToShowDot function. In my case I needed to know the index position of the spot for example. That was not possible to find out while lerp-ing (animation).