### PR TITLE
Update line_chart_painter.dart

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -178,7 +178,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
       if (barData.spots[i].isNotNull()) {
         barList.last.add(barData.spots[i]);
       } else {
-        if (i != 0 && i != barData.spots.length - 1) {
+        if ((i != 0 && i != barData.spots.length - 1) && barList.last.isNotEmpty) {
           barList.add(<FlSpot>[]);
         }
       }


### PR DESCRIPTION
A range error is thrown in _generateBarPath() if we add consecutive null values
for eg: [ FlSpot(1,2), FlSpot(null, null), FlSpot(null, null), FlSpot(4, 4)] will throw range error
(i know its stupid to add consecutive null values but i am that stupid i couldn't understand why m getting range error)

I added  a condition which will take only first null value if there are consecutive null values