### PR TITLE
Removed Range Error if we add consecutive null values in line chart

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -179,7 +179,8 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
       if (barData.spots[i].isNotNull()) {
         barList.last.add(barData.spots[i]);
       } else {
-          if ((i != 0 && i != barData.spots.length - 1) && barList.last.isNotEmpty) {
+          if ((i != 0 && i != barData.spots.length - 1) && 
+              (barList.last.isNotEmpty)) {
           barList.add(<FlSpot>[]);
         }
       }

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -173,12 +173,13 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
 
     // handle nullability by splitting off the list into multiple
     // separate lists when separated by nulls
+    // don't seprate lists if the previous list is already empty
     // and ignore nulls when they're first or last
     for (int i = 0; i < barData.spots.length; i++) {
       if (barData.spots[i].isNotNull()) {
         barList.last.add(barData.spots[i]);
       } else {
-        if (i != 0 && i != barData.spots.length - 1) {
+          if ((i != 0 && i != barData.spots.length - 1) && barList.last.isNotEmpty) {
           barList.add(<FlSpot>[]);
         }
       }


### PR DESCRIPTION
A range error is thrown in _generateBarPath() if we add consecutive null values
for eg: [ FlSpot(1,2), FlSpot(null, null), FlSpot(null, null), FlSpot(4, 4)] will throw range error