### PR TITLE
Fix touch detection of sections spanned across the 0 degrees point

### DIFF
--- a/example/lib/pie_chart/samples/pie_chart_sample2.dart
+++ b/example/lib/pie_chart/samples/pie_chart_sample2.dart
@@ -37,6 +37,7 @@ class PieChart2State extends State {
                           }
                         });
                       }),
+                      startDegreeOffset: -90,
                       borderData: FlBorderData(
                         show: false,
                       ),

--- a/example/lib/pie_chart/samples/pie_chart_sample2.dart
+++ b/example/lib/pie_chart/samples/pie_chart_sample2.dart
@@ -37,7 +37,6 @@ class PieChart2State extends State {
                           }
                         });
                       }),
-                      startDegreeOffset: -90,
                       borderData: FlBorderData(
                         show: false,
                       ),

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -235,7 +235,8 @@ class PieChartPainter extends BaseChartPainter<PieChartData> with TouchHandler<P
     int foundSectionDataPosition;
 
     /// Find the nearest section base on the touch spot
-    double tempAngle = data.startDegreeOffset;
+    final relativeTouchAngle = (touchAngle - data.startDegreeOffset) % 360;
+    double tempAngle = 0.0;
     for (int i = 0; i < data.sections.length; i++) {
       final section = data.sections[i];
       double sectionAngle = sectionsAngle[i];
@@ -247,7 +248,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> with TouchHandler<P
       final space = data.sectionsSpace / 2;
       final fromDegree = tempAngle + space;
       final toDegree = sectionAngle + tempAngle - space;
-      final isInDegree = touchAngle >= fromDegree && touchAngle <= toDegree;
+      final isInDegree = relativeTouchAngle >= fromDegree && relativeTouchAngle <= toDegree;
 
       /// radius criteria
       final centerRadius = _calculateCenterRadius(viewSize, data.centerSpaceRadius);


### PR DESCRIPTION
When using `PieChartData`'s `startDegreeOffset`, it can happen a section spans across the 0 degrees point. 

In such a case, the aforementioned section will not be detected if touched on its "positive" side as the code assumes `fromDegree` will always be lower than `toDegree` (which would not be true here, angles being constrained in the [0:359] range).

This PR fixes this issue by considering the `relativeTouchAngle` which is the touch angle relative to the first section (whatever the `startDegreeOffset` might be). This approach keeps the code simple and now guarantees `fromDegree` will always be smaller than `toDegree`.