### PR TITLE
Fixing issue with only one section that is non-zero

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -246,7 +246,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> with TouchHandler<P
       tempAngle %= 360;
       bool onlyOne = (data.sections.length == 1);
       int numOfNonZeroSec = 0;
-      data.sections.forEach((s) { numOfNonZeroSec += (s.value > 0.0) ? 1 : 0 });
+      data.sections.forEach((s) { numOfNonZeroSec += (s.value > 0.0) ? 1 : 0; });
       if (onlyOne || (numOfNonZeroSec < 2)) {
         sectionAngle = 360;
       } else {
@@ -264,7 +264,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> with TouchHandler<P
       final sectionRadius = centerRadius + section.radius;
       final isInRadius = touchR > centerRadius && touchR <= sectionRadius;
 
-      if (isInDegree && isInRadius) {
+      if (isInDegree && isInRadius && sectionsAngle[i] > 0) {
         foundSectionData = section;
         foundSectionDataPosition = i;
         break;

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -244,7 +244,10 @@ class PieChartPainter extends BaseChartPainter<PieChartData> with TouchHandler<P
       double sectionAngle = sectionsAngle[i];
 
       tempAngle %= 360;
-      if (data.sections.length == 1) {
+      bool onlyOne = (data.sections.length == 1);
+      int numOfNonZeroSec = 0;
+      data.sections.forEach((s) { numOfNonZeroSec += (s.value > 0.0) ? 1 : 0 });
+      if (onlyOne || (numOfNonZeroSec < 2)) {
         sectionAngle = 360;
       } else {
         sectionAngle %= 360;


### PR DESCRIPTION
Fixing an issue when only one section of the pie chart has a non-zero value. In that case, the foundSectionData was returned null, because having only one section yields to `sectionAngle = 0`