### PR TITLE
Fix the setState issue using PieChart in the ListView

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart.dart
+++ b/lib/src/chart/pie_chart/pie_chart.dart
@@ -46,7 +46,9 @@ class _PieChartState extends AnimatedWidgetBaseState<PieChart> {
   void initState() {
     /// Make sure that [_badgeWidgetsOffsets] is updated.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {});
+      if (mounted) {
+        setState(() {});
+      }
     });
     super.initState();
   }


### PR DESCRIPTION
Using pieChart in ListView causes the exception "setState() called after dispose()"