### PR TITLE
Improvement/slidetitle textdirection

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -757,7 +757,7 @@ BarTooltipItem defaultBarTooltipItem(
     fontWeight: FontWeight.bold,
     fontSize: 14,
   );
-  return BarTooltipItem(rod.y.toString(), textStyle);
+  return BarTooltipItem(rod.y.toString(), textStyle, textDirection: TextDirection.ltr);
 }
 
 /// Holds data needed for showing custom tooltip content.
@@ -768,10 +768,14 @@ class BarTooltipItem with EquatableMixin {
   /// TextStyle of the showing content.
   final TextStyle textStyle;
 
+  /// TextDirection of showing content
+  final TextDirection textDirection;
+
   /// content of the tooltip, is a [text] String with a [textStyle].
-  BarTooltipItem(String text, TextStyle textStyle)
+  BarTooltipItem(String text, TextStyle textStyle, {TextDirection textDirection})
       : text = text,
-        textStyle = textStyle;
+        textStyle = textStyle,
+  textDirection = textDirection ?? TextDirection.ltr;
 
   /// Used for equality check, see [EquatableMixin].
   @override

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -366,7 +366,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: leftTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout(maxWidth: getExtraNeededHorizontalSpace());
           x -= tp.width + leftTitles.margin;
@@ -399,7 +399,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
         final TextPainter tp = TextPainter(
             text: span,
             textAlign: TextAlign.center,
-            textDirection: TextDirection.ltr,
+            textDirection: topTitles.textDirection,
             textScaleFactor: textScale);
         tp.layout();
         double x = groupBarPos.groupX;
@@ -435,7 +435,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: rightTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout(maxWidth: getExtraNeededHorizontalSpace());
           x += rightTitles.margin;
@@ -468,7 +468,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
         final TextPainter tp = TextPainter(
             text: span,
             textAlign: TextAlign.center,
-            textDirection: TextDirection.ltr,
+            textDirection: bottomTitles.textDirection,
             textScaleFactor: textScale);
         tp.layout();
         double x = groupBarPos.groupX;
@@ -515,7 +515,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> with TouchHandler<B
     final TextPainter tp = TextPainter(
         text: span,
         textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
+        textDirection: tooltipItem.textDirection,
         textScaleFactor: textScale);
     tp.layout(maxWidth: tooltipData.maxContentWidth);
 

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -250,6 +250,7 @@ bool defaultCheckToShowTitle(
 class SideTitles with EquatableMixin {
   final bool showTitles;
   final GetTitleFunction getTitles;
+  final TextDirection textDirection;
   final double reservedSize;
   final GetTitleTextStyleFunction getTextStyles;
   final double margin;
@@ -278,6 +279,7 @@ class SideTitles with EquatableMixin {
   SideTitles({
     bool showTitles,
     GetTitleFunction getTitles,
+    TextDirection textDirection,
     double reservedSize,
     GetTitleTextStyleFunction getTextStyles,
     double margin,
@@ -286,6 +288,7 @@ class SideTitles with EquatableMixin {
     CheckToShowTitle checkToShowTitle,
   })  : showTitles = showTitles ?? false,
         getTitles = getTitles ?? defaultGetTitle,
+        textDirection = textDirection ?? TextDirection.ltr,
         reservedSize = reservedSize ?? 22,
         getTextStyles = getTextStyles ?? defaultGetTitleTextStyle,
         margin = margin ?? 6,
@@ -302,6 +305,7 @@ class SideTitles with EquatableMixin {
     return SideTitles(
       showTitles: b.showTitles,
       getTitles: b.getTitles,
+      textDirection: b.textDirection,
       reservedSize: lerpDouble(a.reservedSize, b.reservedSize, t),
       getTextStyles: b.getTextStyles,
       margin: lerpDouble(a.margin, b.margin, t),
@@ -316,6 +320,7 @@ class SideTitles with EquatableMixin {
   List<Object> get props => [
         showTitles,
         getTitles,
+        textDirection,
         reservedSize,
         getTextStyles,
         margin,

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1607,8 +1607,12 @@ class LineTooltipItem with EquatableMixin {
   /// Style of showing text.
   final TextStyle textStyle;
 
+  /// text direction od showing text
+  final TextDirection textDirection;
+
   /// Shows a [text] with [textStyle] as a row in the tooltip popup.
-  LineTooltipItem(this.text, this.textStyle);
+  LineTooltipItem(this.text, this.textStyle,
+      {this.textDirection = TextDirection.ltr});
 
   /// Used for equality check, see [EquatableMixin].
   @override

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -862,7 +862,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: leftTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout(maxWidth: getExtraNeededHorizontalSpace());
           x -= tp.width + leftTitles.margin;
@@ -902,7 +902,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: topTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout();
 
@@ -943,7 +943,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: rightTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout(maxWidth: getExtraNeededHorizontalSpace());
 
@@ -983,7 +983,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: bottomTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout();
 
@@ -1170,7 +1170,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
       final TextPainter tp = TextPainter(
           text: span,
           textAlign: TextAlign.center,
-          textDirection: TextDirection.ltr,
+          textDirection: tooltipItem.textDirection,
           textScaleFactor: textScale);
       tp.layout(maxWidth: tooltipData.maxContentWidth);
       drawingTextPainters.add(tp);

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -463,15 +463,20 @@ class ScatterTooltipItem with EquatableMixin {
   /// Defines bottom space from spot.
   final double bottomMargin;
 
+  /// TextDirection of showing text.
+  final TextDirection textDirection;
+
   /// Shows a [text] with [textStyle] in the tooltip popup,
   /// [bottomMargin] is the bottom space from spot.
   ScatterTooltipItem(
     String text,
     TextStyle textStyle,
     double bottomMargin,
-  )   : text = text,
+      {TextDirection textDirection})
+      : text = text,
         textStyle = textStyle,
-        bottomMargin = bottomMargin;
+        bottomMargin = bottomMargin,
+        textDirection = textDirection ?? TextDirection.ltr;
 
   /// Used for equality check, see [EquatableMixin].
   @override

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -84,7 +84,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData>
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: leftTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout(maxWidth: getExtraNeededHorizontalSpace());
           x -= tp.width + leftTitles.margin;
@@ -124,7 +124,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData>
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: topTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout();
 
@@ -165,7 +165,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData>
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: rightTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout(maxWidth: getExtraNeededHorizontalSpace());
 
@@ -206,7 +206,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData>
           final TextPainter tp = TextPainter(
               text: span,
               textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
+              textDirection: bottomTitles.textDirection,
               textScaleFactor: textScale);
           tp.layout();
 
@@ -267,7 +267,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData>
     final TextPainter drawingTextPainter = TextPainter(
         text: span,
         textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
+        textDirection: tooltipItem.textDirection,
         textScaleFactor: textScale);
     drawingTextPainter.layout(maxWidth: tooltipData.maxContentWidth);
 

--- a/test/chart/base/axis_chart_data_test.dart
+++ b/test/chart/base/axis_chart_data_test.dart
@@ -45,6 +45,13 @@ void main() {
       expect(sideTitles1 == sideTitles6, false);
     });
 
+    test('SideTitles TextDirection equality test', () {
+      expect(sideTitles7 == sideTitles6, false);
+      expect(sideTitles7 == sideTitles7Clone, true);
+      expect(sideTitles7.textDirection == sideTitles6.textDirection, false);
+      expect(sideTitles7.textDirection == sideTitles7Clone.textDirection, true);
+    });
+
     test('FlSpot equality test', () {
       expect(flSpot1 == flSpot1Clone, true);
 

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -112,7 +112,26 @@ final SideTitles sideTitles6 = SideTitles(
   interval: 12,
   rotateAngle: 13,
 );
-
+final SideTitles sideTitles7 = SideTitles(
+  margin: 1,
+  reservedSize: 10,
+  getTextStyles: getTextStyles,
+  textDirection: TextDirection.rtl,
+  showTitles: false,
+  getTitles: getTitles,
+  interval: 12,
+  rotateAngle: 13,
+);
+final SideTitles sideTitles7Clone = SideTitles(
+  margin: 1,
+  reservedSize: 10,
+  getTextStyles: getTextStyles,
+  textDirection: TextDirection.rtl,
+  showTitles: false,
+  getTitles: getTitles,
+  interval: 12,
+  rotateAngle: 13,
+);
 final FlTitlesData flTitlesData1 = FlTitlesData(
   show: true,
   bottomTitles: sideTitles1,


### PR DESCRIPTION
I'm using Persian language with this package and it didn't support RTL languages in side titles and tooltips. So I added optional `textDirection` property with `TextDirection.ltr` default value for side titles and tooltip.

