### PR TITLE
Fixes 'Build function can not return null'

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart.dart
+++ b/lib/src/chart/pie_chart/pie_chart.dart
@@ -249,7 +249,7 @@ class _PieChartState extends AnimatedWidgetBaseState<PieChart> {
       }
     }
 
-    return null;
+    return SizedBox();
   }
 
   bool _canHandleTouch(PieTouchResponse response, PieTouchData touchData) {


### PR DESCRIPTION
Fixes `Another exception was thrown: A build function returned null.` when creating a PieChart