### PR TITLE
Add extraVerticalOffset value to VerticalLine

### DIFF
--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1064,6 +1064,10 @@ class VerticalLine extends FlLine with EquatableMixin {
   /// Draws a text label over the line.
   final VerticalLineLabel label;
 
+  /// Additional vertical offset, what can be used to draw outside of the chart area, for example if
+  /// the vertical line should go all the way to the top of the screen.
+  final double extraVerticalOffset;
+
   /// [LineChart] draws vertical lines from bottom to top side of the chart
   /// in the provided [x] value, and color it using [color].
   /// You can define the thickness using [strokeWidth]
@@ -1080,6 +1084,7 @@ class VerticalLine extends FlLine with EquatableMixin {
     Color color,
     double strokeWidth,
     List<int> dashArray,
+    this.extraVerticalOffset,
     this.image,
     this.sizedPicture,
   })  : label = label ?? VerticalLineLabel(),
@@ -1089,6 +1094,7 @@ class VerticalLine extends FlLine with EquatableMixin {
   static VerticalLine lerp(VerticalLine a, VerticalLine b, double t) {
     return VerticalLine(
       x: lerpDouble(a.x, b.x, t),
+      extraVerticalOffset: lerpDouble(a.x, b.x, t),
       label: VerticalLineLabel.lerp(a.label, b.label, t),
       color: Color.lerp(a.color, b.color, t),
       strokeWidth: lerpDouble(a.strokeWidth, b.strokeWidth, t),

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1084,7 +1084,7 @@ class VerticalLine extends FlLine with EquatableMixin {
     Color color,
     double strokeWidth,
     List<int> dashArray,
-    this.extraVerticalOffset,
+    this.extraVerticalOffset = 0,
     this.image,
     this.sizedPicture,
   })  : label = label ?? VerticalLineLabel(),

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1082,7 +1082,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData>
     if (data.extraLinesData.verticalLines.isNotEmpty) {
       for (var line in data.extraLinesData.verticalLines) {
         final topChartPadding = getTopOffsetDrawSize();
-        final from = Offset(getPixelX(line.x, chartUsableSize), topChartPadding);
+        final from = Offset(
+          getPixelX(line.x, chartUsableSize),
+          topChartPadding - line.extraVerticalOffset,
+        );
 
         final bottomChartPadding = getExtraNeededVerticalSpace() - getTopOffsetDrawSize();
         final to = Offset(getPixelX(line.x, chartUsableSize), viewSize.height - bottomChartPadding);


### PR DESCRIPTION
Hi. First of all thanks for the amazing library, it's really awesome!

I have a use-case where I need `VerticalLine` elements to draw outside of the container that the chart is rendered in, all the way to the top of the screen. The best way I thought to achieve this was to add extra property to the `VerticalLine` and use this when drawing the vertical line.

So now we can draw from y location `0 - 300` which will draw a vertical line from 300 pixels above the chart container until the bottom of the container.

What do you think about this idea? Also, please suggest alternative naming for the variable, if you think there is a better name.