### PR TITLE
Allow parallel tooltip on bar chart

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -642,6 +642,9 @@ class BarTouchTooltipData with EquatableMixin {
   /// Controls showing tooltip on top or bottom, default is auto.
   final TooltipDirection direction;
 
+  /// Whether tooltip should be written parallel to bar or perpendicular to it.
+  final bool parallelToBar;
+
   /// if [BarTouchData.handleBuiltInTouches] is true,
   /// [BarChart] shows a tooltip popup on top of rods automatically when touch happens,
   /// otherwise you can show it manually using [BarChartGroupData.showingTooltipIndicators].
@@ -665,6 +668,7 @@ class BarTouchTooltipData with EquatableMixin {
     bool? fitInsideHorizontally,
     bool? fitInsideVertically,
     TooltipDirection? direction,
+    bool? parallelToBar,
   })  : tooltipBgColor = tooltipBgColor ?? Colors.white,
         tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
         tooltipPadding = tooltipPadding ?? const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -674,6 +678,7 @@ class BarTouchTooltipData with EquatableMixin {
         fitInsideHorizontally = fitInsideHorizontally ?? false,
         fitInsideVertically = fitInsideVertically ?? false,
         direction = direction ?? TooltipDirection.auto,
+        parallelToBar = parallelToBar ?? false,
         super();
 
   /// Used for equality check, see [EquatableMixin].

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -546,14 +546,14 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
         : barBottomY + tooltipData.tooltipMargin;
 
     final parallelTooltipTop = drawTooltipOnTop
-      ? barTopY - tooltipHeight * 0.5 - tooltipWidth * 0.25 - tooltipData.tooltipMargin
-      : barBottomY - tooltipHeight * 0.5 + tooltipWidth * 0.75 + tooltipData.tooltipMargin;
+        ? barTopY - tooltipHeight * 0.5 - tooltipWidth * 0.25 - tooltipData.tooltipMargin
+        : barBottomY - tooltipHeight * 0.5 + tooltipWidth * 0.75 + tooltipData.tooltipMargin;
 
     /// draw the background rect with rounded radius
     // ignore: omit_local_variable_types
     Rect rect = tooltipData.parallelToBar
-      ? Rect.fromLTWH(barOffset.dx, parallelTooltipTop, tooltipWidth, tooltipHeight)
-      : Rect.fromLTWH(barOffset.dx - (tooltipWidth / 2), tooltipTop, tooltipWidth, tooltipHeight);
+        ? Rect.fromLTWH(barOffset.dx, parallelTooltipTop, tooltipWidth, tooltipHeight)
+        : Rect.fromLTWH(barOffset.dx - (tooltipWidth / 2), tooltipTop, tooltipWidth, tooltipHeight);
 
     if (tooltipData.fitInsideHorizontally) {
       if (rect.left < 0) {
@@ -615,7 +615,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       canvasWrapper.translate(x + tp.width / 2, y + tp.height / 2);
       canvasWrapper.rotate(radians(angle));
       canvasWrapper.translate(-(x + tp.width / 2), -(y + tp.height / 2));
-        x += translateRotatedPosition(tp.width, angle);
+      x += translateRotatedPosition(tp.width, angle);
       canvasWrapper.drawText(tp, Offset(x, y));
       canvasWrapper.restore();
     } else {


### PR DESCRIPTION
I believe this PR should solve this issue : <https://github.com/imaNNeoFighT/fl_chart/issues/260>

Allows tooltip to be written parallel to bar like this:
<img width="37" alt="Capture d’écran 2021-04-08 à 17 34 53" src="https://user-images.githubusercontent.com/15995331/114055187-d4553a80-9890-11eb-9e2a-e69eef90035a.png">
