### PR TITLE
Bugfix: Index out of bounds for LineChartData spots

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -291,7 +291,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
 
     for (var i = 0; i < barData.showingIndicators.length; i++) {
       final indicatorData = indicatorsData[i];
-      final index = barData.showingIndicators[i];
+      var index = barData.showingIndicators[i];
+      if (index >= barData.spots.length) {
+        index = barData.spots.length - 1;
+      }
       final spot = barData.spots[index];
 
       if (indicatorData == null) {


### PR DESCRIPTION
When changing to another LineChartData of different length while indicator spot is set higher than length of new data this error occured:

```
======== Exception caught by rendering library =====================================================
The following IndexError was thrown during paint():
RangeError (index): Index out of range: index should be less than 5: 170

The relevant error-causing widget was: 
  LineChart file:///Users/xxxxxx/lib/view/widget/dashboard/graph_widget.dart:45:25
When the exception was thrown, this was the stack: 
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 236:49  throw_
dart-sdk/lib/_internal/js_dev_runtime/private/js_array.dart 581:7             _get]
packages/fl_chart/src/chart/line_chart/line_chart_painter.dart 313:27         [_drawTouchedSpotsIndicator]
packages/fl_chart/src/chart/line_chart/line_chart_painter.dart 112:7          paint
packages/fl_chart/src/chart/line_chart/line_chart_renderer.dart 94:14         paint
...
The following RenderObject was being processed when the exception was fired: RenderLineChart#91764 relayoutBoundary=up20
...  parentData: <none> (can use size)
...  constraints: BoxConstraints(0.0<=w<=532.5, h=299.0)
...  size: Size(532.5, 299.0)
RenderObject: RenderLineChart#91764 relayoutBoundary=up20
  parentData: <none> (can use size)
  constraints: BoxConstraints(0.0<=w<=532.5, h=299.0)
  size: Size(532.5, 299.0)
====================================================================================================
```