### PR TITLE
Fix getNearestTouchedSpot

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1416,8 +1416,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
   }
 
   /// find the nearest spot base on the touched offset
-  LineBarSpot? _getNearestTouchedSpot(Size viewSize, Offset touchedPoint, LineChartBarData barData,
-      int barDataPosition, PaintHolder<LineChartData> holder) {
+  LineBarSpot? _getNearestTouchedSpot(
+      Size viewSize,
+      Offset touchedPoint,
+      LineChartBarData barData,
+      int barDataPosition,
+      PaintHolder<LineChartData> holder) {
     final data = holder.data;
     if (!barData.show) {
       return null;
@@ -1425,17 +1429,31 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
 
     final chartViewSize = getChartUsableDrawSize(viewSize, holder);
 
-    /// Find the nearest spot (on X axis)
-    for (var i = 0; i < barData.spots.length; i++) {
-      final spot = barData.spots[i];
-      if (spot.isNotNull()) {
-        if ((touchedPoint.dx - getPixelX(spot.x, chartViewSize, holder)).abs() <=
-            data.lineTouchData.touchSpotThreshold) {
-          return LineBarSpot(barData, barDataPosition, spot);
+    final sortedSpots = <FlSpot>[];
+    double? smallestDistance;
+
+    for (var spot in barData.spots) {
+      if (spot.isNull()) continue;
+
+      final distance =
+      (touchedPoint.dx - getPixelX(spot.x, chartViewSize, holder)).abs();
+
+      if (distance <= data.lineTouchData.touchSpotThreshold) {
+        smallestDistance ??= distance;
+
+        if (distance < smallestDistance) {
+          sortedSpots.insert(0, spot);
+          smallestDistance = distance;
+        } else {
+          sortedSpots.add(spot);
         }
       }
     }
 
-    return null;
+    if (sortedSpots.isNotEmpty) {
+      return LineBarSpot(barData, barDataPosition, sortedSpots.first);
+    } else {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Previously it returned the first occurrence of a spot within the threshold, and not the nearest, which I understand is the purpose of this function.

With the updated function the user is able to set the threshold to a big number (like double.maxFinite) and get the nearest spot from this function. This behaviour (clicking anywhere and get the nearest spot) is seen in e.g. charts_flutter.

AFAIK this shouldn't break anything for existing users, just fix / add the above functionality.

Fixes #641, #645.