### PR TITLE
specify that it uses the short scale for bilions

### DIFF
--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -133,6 +133,7 @@ int _roundInterval(double input) {
 }
 
 /// billion number
+/// in short scale (https://en.wikipedia.org/wiki/Billion)
 const double billion = 1000000000;
 
 /// million number


### PR DESCRIPTION
There are two definitions for the number billion (in short scale and in long scale) as stated in https://en.wikipedia.org/wiki/Billion