### PR TITLE
Dev 0.36.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ You can search in issues to make sure there isn't any already opened issue with 
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Provide us a completely reproducible code (contains the main function) in a file, it helps us to find the bug immediately.
+Provide us a completely reproducible code (contains the main function) in a `main.dart` file, it helps us to find the bug immediately.
 
 **Screenshots**
 If applicable, add screenshots, or videoshots to help explain your problem.

--- a/.github/workflows/check_code_style_pull_request.yml
+++ b/.github/workflows/check_code_style_pull_request.yml
@@ -1,0 +1,20 @@
+name: Code Style Pull Request
+
+on: [pull_request]
+
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    name: Lint flutter code
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v1
+    - run: flutter pub get
+    - name: Analyze Flutter
+      uses: ValentinVignal/action-dart-analyze@v0.11
+      with:
+        fail-on: 'format'
+        line-length: 100

--- a/.github/workflows/check_code_style_push.yml
+++ b/.github/workflows/check_code_style_push.yml
@@ -1,11 +1,10 @@
-name: Code Style
+name: Code Style Push
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   check-code-style:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
       - name: Setup Flutter
@@ -18,3 +17,4 @@ jobs:
         run: flutter pub get
       - name: Analyze the source code
         run: flutter analyze
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## newVersion
+## 0.36.1
 * **IMPROVEMENT** Allow to set zero value on PieChartSectionData (we remove zero sections instead of crashing), #640.
 * **BUGFIX** Fix NPE crash in our renderers touchCallback, #651. 
 * **BUGFIX** Fix line index problem in LineChart, #665. (It has appeared in `0.36.0`, we had to revert 2nd change of `0.36.0`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## newVersion
+* **IMPROVEMENT** Allow to set zero value on PieChartSectionData (we remove zero sections instead of crashing), #640.
+
 ## 0.36.0
 * **BUGFIX** Fixed bug of lerping FlSpot.nullSpot, #487.
 * **BUGFIX** Fixed showing tooltip problem when animating chart, #647.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## newVersion
 * **IMPROVEMENT** Allow to set zero value on PieChartSectionData (we remove zero sections instead of crashing), #640.
 * **BUGFIX** Fix NPE crash in our renderers touchCallback, #651. 
+* **BUGFIX** Fix line index problem in LineChart, #665. (It has appeared in `0.36.0`, we had to revert 2nd change of `0.36.0`)
+* **BREAKING** Remove unused `lineIndex` property from (ShowingTooltipIndicators)[https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#showingtooltipindicators].
 
 ## 0.36.0
 * **BUGFIX** Fixed bug of lerping FlSpot.nullSpot, #487.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## newVersion
 * **IMPROVEMENT** Allow to set zero value on PieChartSectionData (we remove zero sections instead of crashing), #640.
+* **BUGFIX** Fix NPE crash in our renderers touchCallback, #651. 
 
 ## 0.36.0
 * **BUGFIX** Fixed bug of lerping FlSpot.nullSpot, #487.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# FL Chart
-
+💥 A library to draw fantastic charts in Flutter  💥
 
 
 [![pub package](https://img.shields.io/pub/v/fl_chart.svg)](https://pub.dartlang.org/packages/fl_chart)
@@ -7,20 +6,17 @@
 
 ![FL Chart Logo](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/landing_logo.jpg)
 
-
-💥 A library to draw fantastic charts in Flutter  💥
-
 ### Chart Types
 
 |LineChart	|BarChart		|PieChart		|
 |:------------:|:------------:|:-------------:|
 |	[![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/line_chart/line_chart_sample_1.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#sample-1-source-code) [![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/line_chart/line_chart_sample_2.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#sample-2-source-code)  |	[![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/bar_chart/bar_chart_sample_1.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/bar_chart.md#sample-1-source-code) [![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/bar_chart/bar_chart_sample_2.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/bar_chart.md#sample-2-source-code)  | [![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/pie_chart/pie_chart_sample_1.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/pie_chart.md#sample-1-source-code) [![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/pie_chart/pie_chart_sample_2.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/pie_chart.md#sample-2-source-code) |
-|[Read More](repo_files/documentations/line_chart.md)|[Read More](repo_files/documentations/bar_chart.md)|[Read More](repo_files/documentations/pie_chart.md)|
+|[Read More](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md)|[Read More](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/bar_chart.md)|[Read More](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/pie_chart.md)|
 
 |ScatterChart	|RadarChart| Coming Soon|
 |:------------:|:------------:|:-------------:|
 |	[![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/scatter_chart/scatter_chart_sample_1.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/scatter_chart.md#sample-1-source-code) [![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/scatter_chart/scatter_chart_sample_2.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/scatter_chart.md#sample-2-source-code)  |	![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/radar_chart/radar_chart_sample_1.jpg)  ![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/blank.jpg)|![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/blank.jpg) ![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/blank.jpg)|
-|[Read More](repo_files/documentations/scatter_chart.md)|[Read More](repo_files/documentations/radar_chart.md)||
+|[Read More](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/scatter_chart.md)|[Read More](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/radar_chart.md)||
 
 Banner designed by [Soheil Saffar](https://www.linkedin.com/in/soheilsaffar), and
 samples inspired from
@@ -53,9 +49,9 @@ flutter packages get
 ```
 
 ### 3 - Learn it like a charm
-##### Read the docs from [here](repo_files/documentations/index.md)
+##### Read the docs from [here](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/index.md)
 
-##### - [Animations](repo_files/documentations/handle_animations.md)
+##### - [Animations](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/handle_animations.md)
 |Sample1	|Sample2		|Sample3		|
 |:------------:|:------------:|:-------------:|
 |	[![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/line_chart/line_chart_sample_1_anim.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#sample-1-source-code)   |	[![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/line_chart/line_chart_sample_2_anim.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#sample-2-source-code) | [![](https://github.com/imaNNeoFighT/fl_chart/raw/master/repo_files/images/bar_chart/bar_chart_sample_1_anim.gif)](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/bar_chart.md#sample-1-source-code) |
@@ -72,5 +68,5 @@ flutter packages get
 
 ### Contributing
 
-Check out [CONTRIBUTING.md](CONTRIBUTING.md), which contains a guide for those
+Check out [CONTRIBUTING.md](https://github.com/imaNNeoFighT/fl_chart/blob/master/CONTRIBUTING.md), which contains a guide for those
 who wish to contribute to FL Chart. Thanks in advance!

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Thank you all!
 
 ```yml
 dependencies:
-  fl_chart: ^0.36.0
+  fl_chart: ^0.36.1
 ```
 
 

--- a/example/lib/line_chart/samples/line_chart_sample5.dart
+++ b/example/lib/line_chart/samples/line_chart_sample5.dart
@@ -54,8 +54,9 @@ class LineChartSample5 extends StatelessWidget {
       child: LineChart(
         LineChartData(
           showingTooltipIndicators: showIndexes.map((index) {
-            return ShowingTooltipIndicators(0, [
-              index,
+            return ShowingTooltipIndicators([
+              LineBarSpot(
+                  tooltipsOnBar, lineBarsData.indexOf(tooltipsOnBar), tooltipsOnBar.spots[index]),
             ]);
           }).toList(),
           lineTouchData: LineTouchData(

--- a/lib/src/chart/bar_chart/bar_chart_renderer.dart
+++ b/lib/src/chart/bar_chart/bar_chart_renderer.dart
@@ -109,7 +109,7 @@ class RenderBarChart extends RenderBox {
 
     var touchedSpot = _painter.handleTouch(event, size, paintHolder);
     if (touchedSpot == null) {
-      _touchCallback!.call(response);
+      _touchCallback?.call(response);
       return;
     }
     response = response.copyWith(spot: touchedSpot);
@@ -123,6 +123,6 @@ class RenderBarChart extends RenderBox {
       _lastTouchedSpot = null;
     }
 
-    _touchCallback!.call(response);
+    _touchCallback?.call(response);
   }
 }

--- a/lib/src/chart/line_chart/line_chart.dart
+++ b/lib/src/chart/line_chart/line_chart.dart
@@ -97,8 +97,7 @@ class _LineChartState extends AnimatedWidgetBaseState<LineChart> {
         }
 
         _showingTouchedTooltips.clear();
-        _showingTouchedTooltips
-            .add(ShowingTooltipIndicators(0, sortedLineSpots.map((e) => e.spotIndex).toList()));
+        _showingTouchedTooltips.add(ShowingTooltipIndicators(sortedLineSpots));
       });
     } else {
       setState(() {

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1682,22 +1682,16 @@ class TouchedSpotIndicatorData with EquatableMixin {
 
 /// Holds data for showing tooltips over a line
 class ShowingTooltipIndicators with EquatableMixin {
-  /// Determines in which line these tooltips should be shown.
-  final int lineIndex;
-
   /// Determines the spots that each tooltip should be shown.
-  final List<int> spotsIndices;
+  final List<LineBarSpot> showingSpots;
 
   /// [LineChart] shows some tooltips over each [LineChartBarData],
-  /// [lineIndex] determines the index of [LineChartBarData],
-  /// and [spotsIndices] determines in which spots this tooltip should be shown.
-  ShowingTooltipIndicators(int lineIndex, List<int> spotsIndices)
-      : lineIndex = lineIndex,
-        spotsIndices = spotsIndices;
+  /// and [showingSpots] determines in which spots this tooltip should be shown.
+  ShowingTooltipIndicators(List<LineBarSpot> showingSpots) : showingSpots = showingSpots;
 
   /// Used for equality check, see [EquatableMixin].
   @override
-  List<Object?> get props => [lineIndex, spotsIndices];
+  List<Object?> get props => [showingSpots];
 }
 
 /// [LineChart]'s touch callback.

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -66,8 +66,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
   @override
   void paint(CanvasWrapper canvasWrapper, PaintHolder<LineChartData> holder) {
     final data = holder.data;
-    final targetData = holder.targetData;
-    if (data.lineBarsData.isEmpty || targetData.lineBarsData.isEmpty) {
+    if (data.lineBarsData.isEmpty) {
       return;
     }
 
@@ -116,28 +115,24 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     _drawTitles(canvasWrapper, holder);
 
     // Draw touch tooltip on most top spot
-    for (var i = 0; i < targetData.showingTooltipIndicators.length; i++) {
-      var tooltipSpots = targetData.showingTooltipIndicators[i];
+    for (var i = 0; i < data.showingTooltipIndicators.length; i++) {
+      var tooltipSpots = data.showingTooltipIndicators[i];
 
-      final showingBarSpots = tooltipSpots.spotsIndices;
+      final showingBarSpots = tooltipSpots.showingSpots;
       if (showingBarSpots.isEmpty) {
         continue;
       }
-      final barSpotsIndex = List<int>.of(showingBarSpots);
-      final line = targetData.lineBarsData[tooltipSpots.lineIndex];
-      var topSpot = line.spots[barSpotsIndex.first];
-      for (var index in barSpotsIndex) {
-        final checkingSpot = line.spots[index];
-        if (checkingSpot.y > topSpot.y) {
-          print(index);
-          topSpot = checkingSpot;
+      final barSpots = List<LineBarSpot>.of(showingBarSpots);
+      FlSpot topSpot = barSpots[0];
+      for (var barSpot in barSpots) {
+        if (barSpot.y > topSpot.y) {
+          topSpot = barSpot;
         }
       }
-      tooltipSpots = ShowingTooltipIndicators(tooltipSpots.lineIndex, barSpotsIndex);
+      tooltipSpots = ShowingTooltipIndicators(barSpots);
 
       _drawTouchTooltip(
         canvasWrapper,
-        line,
         data.lineTouchData.touchTooltipData,
         topSpot,
         tooltipSpots,
@@ -1147,7 +1142,6 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
 
   void _drawTouchTooltip(
       CanvasWrapper canvasWrapper,
-      LineChartBarData barLine,
       LineTouchTooltipData tooltipData,
       FlSpot showOnSpot,
       ShowingTooltipIndicators showingTooltipSpots,
@@ -1160,17 +1154,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     /// creating TextPainters to calculate the width and height of the tooltip
     final drawingTextPainters = <TextPainter>[];
 
-    final barLineIndex = showingTooltipSpots.lineIndex;
-
-    final lineBarSpots = showingTooltipSpots.spotsIndices
-        .map((index) => LineBarSpot(barLine, barLineIndex, barLine.spots[index]))
-        .toList();
-    final tooltipItems = tooltipData.getTooltipItems(lineBarSpots);
-    if (tooltipItems.length != showingTooltipSpots.spotsIndices.length) {
+    final tooltipItems = tooltipData.getTooltipItems(showingTooltipSpots.showingSpots);
+    if (tooltipItems.length != showingTooltipSpots.showingSpots.length) {
       throw Exception('tooltipItems and touchedSpots size should be same');
     }
 
-    for (var i = 0; i < showingTooltipSpots.spotsIndices.length; i++) {
+    for (var i = 0; i < showingTooltipSpots.showingSpots.length; i++) {
       final tooltipItem = tooltipItems[i];
       if (tooltipItem == null) {
         continue;

--- a/lib/src/chart/line_chart/line_chart_renderer.dart
+++ b/lib/src/chart/line_chart/line_chart_renderer.dart
@@ -108,7 +108,7 @@ class RenderLineChart extends RenderBox {
 
     var touchedSpots = _painter.handleTouch(event, size, paintHolder);
     if (touchedSpots == null || touchedSpots.isEmpty) {
-      _touchCallback!.call(response);
+      _touchCallback?.call(response);
       return;
     }
     response = response.copyWith(lineBarSpots: touchedSpots);
@@ -122,6 +122,6 @@ class RenderLineChart extends RenderBox {
       _lastTouchedSpots = null;
     }
 
-    _touchCallback!.call(response);
+    _touchCallback?.call(response);
   }
 }

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -53,11 +53,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
     double? startDegreeOffset,
     PieTouchData? pieTouchData,
     FlBorderData? borderData,
-  })  : assert(
-          !_sectionsContainsZero(sections),
-          "section's value can't be zero",
-        ),
-        sections = sections ?? const [],
+  })  : sections = sections?.where((section) => section.value != 0).toList() ?? const [],
         centerSpaceRadius = centerSpaceRadius ?? double.infinity,
         centerSpaceColor = centerSpaceColor ?? Colors.transparent,
         sectionsSpace = sectionsSpace ?? 2,
@@ -67,14 +63,6 @@ class PieChartData extends BaseChartData with EquatableMixin {
           borderData: borderData ?? FlBorderData(show: false),
           touchData: pieTouchData ?? PieTouchData(),
         );
-
-  /// Returns true if find any zero value in the list.
-  static bool _sectionsContainsZero(List<PieChartSectionData>? list) {
-    if (list == null) {
-      return false;
-    }
-    return list.any((element) => element.value == 0);
-  }
 
   /// Copies current [PieChartData] to a new [PieChartData],
   /// and replaces provided values.

--- a/lib/src/chart/pie_chart/pie_chart_renderer.dart
+++ b/lib/src/chart/pie_chart/pie_chart_renderer.dart
@@ -155,7 +155,7 @@ class RenderPieChart extends RenderBox
 
     var touchedSection = _painter.handleTouch(event, size, paintHolder);
     if (touchedSection == null) {
-      _touchCallback!.call(response);
+      _touchCallback?.call(response);
       return;
     }
     response = response.copyWith(touchedSection: touchedSection);
@@ -169,6 +169,6 @@ class RenderPieChart extends RenderBox
       _lastTouchedSpot = null;
     }
 
-    _touchCallback!.call(response);
+    _touchCallback?.call(response);
   }
 }

--- a/lib/src/chart/radar_chart/radar_chart_renderer.dart
+++ b/lib/src/chart/radar_chart/radar_chart_renderer.dart
@@ -109,7 +109,7 @@ class RenderRadarChart extends RenderBox {
 
     var touchedSpot = _painter.handleTouch(event, size, paintHolder);
     if (touchedSpot == null) {
-      _touchCallback!.call(response);
+      _touchCallback?.call(response);
       return;
     }
     response = response.copyWith(
@@ -125,6 +125,6 @@ class RenderRadarChart extends RenderBox {
       _lastTouchedSpot = null;
     }
 
-    _touchCallback!.call(response);
+    _touchCallback?.call(response);
   }
 }

--- a/lib/src/chart/scatter_chart/scatter_chart_renderer.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_renderer.dart
@@ -110,7 +110,7 @@ class RenderScatterChart extends RenderBox {
 
     var touchedSpot = _painter.handleTouch(event, size, paintHolder);
     if (touchedSpot == null) {
-      _touchCallback!.call(response);
+      _touchCallback?.call(response);
       return;
     }
     response = response.copyWith(touchedSpot: touchedSpot);
@@ -124,6 +124,6 @@ class RenderScatterChart extends RenderBox {
       _lastTouchedSpot = null;
     }
 
-    _touchCallback!.call(response);
+    _touchCallback?.call(response);
   }
 }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -133,6 +133,7 @@ int _roundInterval(double input) {
 }
 
 /// billion number
+/// in short scale (https://en.wikipedia.org/wiki/Billion)
 const double billion = 1000000000;
 
 /// million number

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A powerful Flutter chart library, currently supporting Line Chart, Bar Chart and Pie Chart.
-version: 0.36.0
+version: 0.36.1
 homepage: https://github.com/imaNNeoFighT/fl_chart
 
 environment:

--- a/repo_files/documentations/handle_animations.md
+++ b/repo_files/documentations/handle_animations.md
@@ -7,11 +7,13 @@
 We handle all animations Implicitly, This is power of the [ImplicitlyAnimatedWidget](https://api.flutter.dev/flutter/widgets/ImplicitlyAnimatedWidget-class.html), just like [AnimatedContainer](https://api.flutter.dev/flutter/widgets/AnimatedContainer-class.html). It means you don't need to do anything, just change any value and the animation is handled under the hood, if you are curious about it, check the source code, reading the source code is the best way to learn things.
 
 
-##### Duration
-we added an optional argument in the `FlChart` class called  `swapAnimationDuration`, this is a [Duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) class that you can set the duration of the animation. the default value is `150 ms`, you can change it to fit your requirements.
+##### Properties
+You can change the [Duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [Curve](https://api.flutter.dev/flutter/animation/Curves-class.html) of animation using `swapAnimationDuration` and `swapAnimationCurve` properties respectively.
+
 ```dart
 LineChart(
   swapAnimationDuration: Duration(milliseconds: 150),
+  swapAnimationCurve = Curves.linear,
   LineChartData(
     isShowingMainData ? sampleData1() : sampleData2(),
   ),
@@ -20,4 +22,4 @@ LineChart(
 
 ##### How to disable
 
-If you want to disable animation, I you should set the duration `0`.
+If you want to disable the animations, you can set `Duration.zero` as `swapAnimationDuration`.

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -26,7 +26,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |extraLinesData| [ExtraLinesData](#ExtraLinesData) object to hold drawing details of extra horizontal and vertical lines.|
 |lineTouchData| [LineTouchData](#linetouchdata-read-about-touch-handling) holds the touch interactivity details| LineTouchData()|
 |rangeAnnotations| show range annotations behind the chart, check [RangeAnnotations](base_chart.md#RangeAnnotations) | RangeAnnotations()|
-|showingTooltipIndicators| show the tooltip based on provided position(x), and list of [LineBarSpot](#LineBarSpot)| [] |
+|showingTooltipIndicators| show the tooltip based on provided list of [LineBarSpot](#LineBarSpot)| [] |
 |gridData| check the [FlGridData](base_chart.md#FlGridData)|FlGridData()|
 |borderData| check the [FlBorderData](base_chart.md#FlBorderData)|FlBorderData()|
 |minX| gets minimum x of x axis, if null, value will read from the input lineBars |null|
@@ -222,7 +222,6 @@ When you change the chart's state, it animates to the new state internally (usin
 ### ShowingTooltipIndicators
 |PropName|Description|default value|
 |:-------|:----------|:------------|
-|lineIndex|Determines in which line these tooltips should be shown.|null|
 |showingSpots|Determines the spots that each tooltip should be shown.|null|
 
 

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -1533,28 +1533,22 @@ final BetweenBarsData betweenBarsData8 = BetweenBarsData(
 );
 
 final ShowingTooltipIndicators showingTooltipIndicator1 = ShowingTooltipIndicators(
-  1,
-  [1, 2],
+  [lineBarSpot1, lineBarSpot2],
 );
 final ShowingTooltipIndicators showingTooltipIndicator1Clone = ShowingTooltipIndicators(
-  1,
-  [1, 2],
+  [lineBarSpot1, lineBarSpot2],
 );
 final ShowingTooltipIndicators showingTooltipIndicator2 = ShowingTooltipIndicators(
-  33,
   [],
 );
 final ShowingTooltipIndicators showingTooltipIndicator3 = ShowingTooltipIndicators(
-  1,
-  [],
+  [lineBarSpot2],
 );
 final ShowingTooltipIndicators showingTooltipIndicator4 = ShowingTooltipIndicators(
-  1,
-  [2, 1],
+  [lineBarSpot2, lineBarSpot1],
 );
 final ShowingTooltipIndicators showingTooltipIndicator5 = ShowingTooltipIndicators(
-  2,
-  [1, 2],
+  [lineBarSpot1, lineBarSpot2, lineBarSpot2],
 );
 
 final LineChartData lineChartData1 = LineChartData(


### PR DESCRIPTION
* **IMPROVEMENT** Allow to set zero value on PieChartSectionData (we remove zero sections instead of crashing), #640.
* **BUGFIX** Fix NPE crash in our renderers touchCallback, #651. 
* **BUGFIX** Fix line index problem in LineChart, #665. (It has appeared in `0.36.0`, we had to revert 2nd change of `0.36.0`)
* **BREAKING** Remove unused `lineIndex` property from (ShowingTooltipIndicators)[https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#showingtooltipindicators].
