### PR TITLE
Left and Right side titles alignment to the chart viewport edge

### DIFF
--- a/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/example/lib/line_chart/line_chart_page5.dart
+++ b/example/lib/line_chart/line_chart_page5.dart
@@ -1,0 +1,57 @@
+import 'package:example/line_chart/samples/line_chart_sample11.dart';
+import 'package:flutter/material.dart';
+
+class LineChartPage5 extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      child: Center(
+        child: ListView(
+          padding: EdgeInsets.symmetric(horizontal: 28, vertical: 18),
+          children: <Widget>[
+            const Text(
+              'LineChart (Left titles alignment to the left and '
+              'Right titles alignment to the right example)',
+              style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold, color: Colors.black),
+            ),
+            const SizedBox(height: 52),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10.0),
+              child: Text('Without alignment', style: TextStyle(color: Colors.black)),
+            ),
+            Container(
+              child: Padding(
+                padding: const EdgeInsets.only(top: 10, bottom: 10),
+                child: LineChartSample11(),
+              ),
+              decoration: BoxDecoration(
+                border: Border(
+                    left: BorderSide(color: Colors.black, width: 0.5),
+                    right: BorderSide(color: Colors.black, width: 0.5)),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10.0),
+              child: Text('With alignment', style: TextStyle(color: Colors.black)),
+            ),
+            Container(
+              child: Padding(
+                padding: const EdgeInsets.only(top: 10, bottom: 10),
+                child: LineChartSample11(
+                  alignYMarksLeft: true,
+                  alignYMarksRight: true,
+                ),
+              ),
+              decoration: BoxDecoration(
+                border: Border(
+                    left: BorderSide(color: Colors.black, width: 0.5),
+                    right: BorderSide(color: Colors.black, width: 0.5)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/line_chart/samples/line_chart_sample11.dart
+++ b/example/lib/line_chart/samples/line_chart_sample11.dart
@@ -1,0 +1,101 @@
+import 'dart:math';
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+// ignore: must_be_immutable
+class LineChartSample11 extends StatelessWidget {
+  final spots = List.generate(101, (i) => (i - 50) / 10).map((x) => FlSpot(x, sin(x))).toList();
+  final bool alignYMarksLeft, alignYMarksRight;
+
+  LineChartSample11({
+    this.alignYMarksLeft = false,
+    this.alignYMarksRight = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: SizedBox(
+        width: 400,
+        height: 200,
+        child: LineChart(
+          LineChartData(
+            lineTouchData: LineTouchData(
+              touchTooltipData: LineTouchTooltipData(
+                  maxContentWidth: 100,
+                  tooltipBgColor: Colors.orange,
+                  getTooltipItems: (touchedSpots) {
+                    return touchedSpots.map((LineBarSpot touchedSpot) {
+                      final textStyle = TextStyle(
+                        color: touchedSpot.bar.colors[0],
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      );
+                      return LineTooltipItem(
+                          '${touchedSpot.x}, ${touchedSpot.y.toStringAsFixed(2)}', textStyle);
+                    }).toList();
+                  }),
+              handleBuiltInTouches: true,
+              getTouchLineStart: (data, index) => 0,
+            ),
+            lineBarsData: [
+              LineChartBarData(
+                colors: [
+                  Colors.black,
+                ],
+                spots: spots,
+                isCurved: true,
+                isStrokeCapRound: true,
+                barWidth: 3,
+                belowBarData: BarAreaData(
+                  show: false,
+                ),
+                dotData: FlDotData(show: false),
+              ),
+            ],
+            minY: -1.5,
+            maxY: 1.5,
+            titlesData: FlTitlesData(
+              leftTitles: SideTitles(
+                showTitles: true,
+                getTextStyles: (value) => const TextStyle(
+                    color: Colors.blueGrey, fontWeight: FontWeight.bold, fontSize: 18),
+                margin: 25,
+                alignLeftTitlesToLeft: alignYMarksLeft,
+              ),
+              rightTitles: SideTitles(
+                showTitles: true,
+                getTextStyles: (value) => const TextStyle(
+                    color: Colors.blueGrey, fontWeight: FontWeight.bold, fontSize: 18),
+                margin: 25,
+                alignRightTitlesToRight: alignYMarksRight,
+              ),
+              bottomTitles: SideTitles(
+                showTitles: true,
+                getTextStyles: (value) => const TextStyle(
+                    color: Colors.blueGrey, fontWeight: FontWeight.bold, fontSize: 18),
+                margin: 16,
+              ),
+              topTitles: SideTitles(showTitles: false),
+            ),
+            gridData: FlGridData(
+              show: true,
+              drawHorizontalLine: true,
+              drawVerticalLine: true,
+              horizontalInterval: 1.5,
+              verticalInterval: 5,
+              checkToShowHorizontalLine: (value) {
+                return value.toInt() == 0;
+              },
+              checkToShowVerticalLine: (value) {
+                return value.toInt() == 0;
+              },
+            ),
+            borderData: FlBorderData(show: false),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/line_chart/line_chart_page5.dart';
 import 'package:example/radar_chart/radar_chart_page.dart';
 import 'package:example/scatter_chart/scatter_chart_page.dart';
 import 'package:flutter/foundation.dart';
@@ -54,6 +55,7 @@ class _MyHomePageState extends State<MyHomePage> {
     LineChartPage2(),
     LineChartPage3(),
     LineChartPage4(),
+    LineChartPage5(),
     BarChartPage3(),
     ScatterChartPage(),
     RadarChartPage(),

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -265,6 +265,9 @@ class SideTitles with EquatableMixin {
   final double rotateAngle;
   final CheckToShowTitle checkToShowTitle;
 
+  final bool alignRightTitlesToRight;
+  final bool alignLeftTitlesToLeft;
+
   /// It draws some title on all axis, per each axis value,
   /// [showTitles] determines showing or hiding this side,
   /// texts are depend on the axis value, you can override [getTitles],
@@ -296,6 +299,8 @@ class SideTitles with EquatableMixin {
     double? interval,
     double? rotateAngle,
     CheckToShowTitle? checkToShowTitle,
+    bool? alignRightTitlesToRight,
+    bool? alignLeftTitlesToLeft,
   })  : showTitles = showTitles ?? false,
         getTitles = getTitles ?? defaultGetTitle,
         reservedSize = reservedSize ?? 22,
@@ -304,7 +309,9 @@ class SideTitles with EquatableMixin {
         margin = margin ?? 6,
         interval = interval,
         rotateAngle = rotateAngle ?? 0.0,
-        checkToShowTitle = checkToShowTitle ?? defaultCheckToShowTitle {
+        checkToShowTitle = checkToShowTitle ?? defaultCheckToShowTitle,
+        alignLeftTitlesToLeft = alignLeftTitlesToLeft ?? false,
+        alignRightTitlesToRight = alignRightTitlesToRight ?? false {
     if (interval == 0) {
       throw ArgumentError("SideTitles.interval couldn't be zero");
     }

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -849,9 +849,6 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       while (verticalSeek <= data.maxY) {
         if (leftTitles.checkToShowTitle(
             data.minY, data.maxY, leftTitles, leftInterval, verticalSeek)) {
-          var x = 0 + getLeftOffsetDrawSize(holder);
-          var y = getPixelY(verticalSeek, viewSize, holder);
-
           final text = leftTitles.getTitles(verticalSeek);
 
           final span = TextSpan(style: leftTitles.getTextStyles(verticalSeek), text: text);
@@ -861,9 +858,18 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
               textDirection: leftTitles.textDirection,
               textScaleFactor: holder.textScale);
           tp.layout(maxWidth: getExtraNeededHorizontalSpace(holder));
-          x -= tp.width + leftTitles.margin;
+
+          double x;
+          if (leftTitles.alignLeftTitlesToLeft) {
+            x = 0;
+          } else {
+            x = getLeftOffsetDrawSize(holder);
+            x -= tp.width + leftTitles.margin;
+            x += calculateRotationOffset(tp.size, leftTitles.rotateAngle).dx;
+          }
+
+          var y = getPixelY(verticalSeek, viewSize, holder);
           y -= tp.height / 2;
-          x += calculateRotationOffset(tp.size, leftTitles.rotateAngle).dx;
           canvasWrapper.drawText(tp, Offset(x, y), leftTitles.rotateAngle);
         }
         if (data.maxY - verticalSeek < leftInterval && data.maxY != verticalSeek) {
@@ -918,9 +924,6 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       while (verticalSeek <= data.maxY) {
         if (rightTitles.checkToShowTitle(
             data.minY, data.maxY, rightTitles, rightInterval, verticalSeek)) {
-          var x = viewSize.width + getLeftOffsetDrawSize(holder);
-          var y = getPixelY(verticalSeek, viewSize, holder);
-
           final text = rightTitles.getTitles(verticalSeek);
 
           final span = TextSpan(style: rightTitles.getTextStyles(verticalSeek), text: text);
@@ -931,9 +934,18 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
               textScaleFactor: holder.textScale);
           tp.layout(maxWidth: getExtraNeededHorizontalSpace(holder));
 
-          x += rightTitles.margin;
+          double x;
+          if (rightTitles.alignRightTitlesToRight) {
+            x = canvasWrapper.size.width - tp.width;
+          } else {
+            x = viewSize.width + getLeftOffsetDrawSize(holder);
+            x += rightTitles.margin;
+            x -= calculateRotationOffset(tp.size, rightTitles.rotateAngle).dx;
+          }
+
+          var y = getPixelY(verticalSeek, viewSize, holder);
+
           y -= tp.height / 2;
-          x -= calculateRotationOffset(tp.size, rightTitles.rotateAngle).dx;
           canvasWrapper.drawText(tp, Offset(x, y), rightTitles.rotateAngle);
         }
 


### PR DESCRIPTION
Often designers create prototypes for screens containing a chart drawing the chart Y marks aligned with screen content to the screen left and right paddings. This code allows doing that.

It is enough to add one param to the SideTitles constructor

SideTitles _getRightForecastChartTitles(double yInterval) => SideTitles(
...
alignRightTitlesToRight: true,
);

Also, I added an example (which can be deleted if it does not suit)

Screenshot of the example

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-07-27 at 06 05 43](https://user-images.githubusercontent.com/4295256/127091205-d8bfc1b0-665b-49c9-be3e-499c188f84f2.png)

Issue:

https://github.com/imaNNeoFighT/fl_chart/issues/724
