### PR TITLE
Refactoring line_chart_sample_1

### DIFF
--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -28,13 +28,7 @@ class _LineChart extends StatelessWidget {
       ),
       titlesData: FlTitlesData(
         bottomTitles: bottomTitles(),
-        leftTitles: SideTitles(
-          showTitles: true,
-          getTextStyles: (value) => const TextStyle(
-            color: Color(0xff75729e),
-            fontWeight: FontWeight.bold,
-            fontSize: 14,
-          ),
+        leftTitles: leftTitles(
           getTitles: (value) {
             switch (value.toInt()) {
               case 1:
@@ -48,8 +42,6 @@ class _LineChart extends StatelessWidget {
             }
             return '';
           },
-          margin: 8,
-          reservedSize: 30,
         ),
       ),
       borderData: FlBorderData(
@@ -162,13 +154,7 @@ class _LineChart extends StatelessWidget {
       ),
       titlesData: FlTitlesData(
         bottomTitles: bottomTitles(),
-        leftTitles: SideTitles(
-          showTitles: true,
-          getTextStyles: (value) => const TextStyle(
-            color: Color(0xff75729e),
-            fontWeight: FontWeight.bold,
-            fontSize: 14,
-          ),
+        leftTitles: leftTitles(
           getTitles: (value) {
             switch (value.toInt()) {
               case 1:
@@ -184,8 +170,6 @@ class _LineChart extends StatelessWidget {
             }
             return '';
           },
-          margin: 8,
-          reservedSize: 30,
         ),
       ),
       borderData: FlBorderData(
@@ -282,6 +266,20 @@ class _LineChart extends StatelessWidget {
         ),
       ),
     ];
+  }
+
+  SideTitles leftTitles({required GetTitleFunction getTitles}) {
+    return SideTitles(
+      showTitles: true,
+      getTextStyles: (value) => const TextStyle(
+        color: Color(0xff75729e),
+        fontWeight: FontWeight.bold,
+        fontSize: 14,
+      ),
+      getTitles: getTitles,
+      margin: 8,
+      reservedSize: 30,
+    );
   }
 
   SideTitles bottomTitles() {

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -9,26 +9,24 @@ class _LineChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LineChart(
-      isShowingMainData ? sampleData1() : sampleData2(),
+      isShowingMainData ? sampleData1 : sampleData2(),
       swapAnimationDuration: const Duration(milliseconds: 250),
     );
   }
 
-  LineChartData sampleData1() {
-    return LineChartData(
-      lineTouchData: lineTouchData1(),
-      gridData: FlGridData(show: false),
-      titlesData: titlesData1(),
-      borderData: borderData(),
-      lineBarsData: linesBarData1(),
-      minX: 0,
-      maxX: 14,
-      maxY: 4,
-      minY: 0,
-    );
-  }
+  LineChartData get sampleData1 => LineChartData(
+        lineTouchData: lineTouchData1,
+        gridData: FlGridData(show: false),
+        titlesData: titlesData1,
+        borderData: borderData,
+        lineBarsData: linesBarData1,
+        minX: 0,
+        maxX: 14,
+        maxY: 4,
+        minY: 0,
+      );
 
-  LineTouchData lineTouchData1() => LineTouchData(
+  LineTouchData get lineTouchData1 => LineTouchData(
         touchTooltipData: LineTouchTooltipData(
           tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
         ),
@@ -36,7 +34,7 @@ class _LineChart extends StatelessWidget {
         handleBuiltInTouches: true,
       );
 
-  FlTitlesData titlesData1() => FlTitlesData(
+  FlTitlesData get titlesData1 => FlTitlesData(
         bottomTitles: bottomTitles(),
         leftTitles: leftTitles(
           getTitles: (value) {
@@ -55,11 +53,11 @@ class _LineChart extends StatelessWidget {
         ),
       );
 
-  List<LineChartBarData> linesBarData1() => [
-    lineChartBarData1_1,
-    lineChartBarData1_2,
-    lineChartBarData1_3,
-  ];
+  List<LineChartBarData> get linesBarData1 => [
+        lineChartBarData1_1,
+        lineChartBarData1_2,
+        lineChartBarData1_3,
+      ];
 
   LineChartData sampleData2() {
     return LineChartData(
@@ -89,7 +87,7 @@ class _LineChart extends StatelessWidget {
           },
         ),
       ),
-      borderData: borderData(),
+      borderData: borderData,
       minX: 0,
       maxX: 14,
       maxY: 6,
@@ -207,93 +205,91 @@ class _LineChart extends StatelessWidget {
     );
   }
 
-  FlBorderData borderData() {
-    return FlBorderData(
-      show: true,
-      border: const Border(
-        bottom: BorderSide(
-          color: Color(0xff4e4965),
-          width: 4,
+  FlBorderData get borderData => FlBorderData(
+        show: true,
+        border: const Border(
+          bottom: BorderSide(
+            color: Color(0xff4e4965),
+            width: 4,
+          ),
+          left: BorderSide(
+            color: Colors.transparent,
+          ),
+          right: BorderSide(
+            color: Colors.transparent,
+          ),
+          top: BorderSide(
+            color: Colors.transparent,
+          ),
         ),
-        left: BorderSide(
-          color: Colors.transparent,
-        ),
-        right: BorderSide(
-          color: Colors.transparent,
-        ),
-        top: BorderSide(
-          color: Colors.transparent,
-        ),
-      ),
-    );
-  }
+      );
 
   LineChartBarData get lineChartBarData1_1 => LineChartBarData(
-    spots: [
-      FlSpot(1, 1),
-      FlSpot(3, 1.5),
-      FlSpot(5, 1.4),
-      FlSpot(7, 3.4),
-      FlSpot(10, 2),
-      FlSpot(12, 2.2),
-      FlSpot(13, 1.8),
-    ],
-    isCurved: true,
-    colors: [const Color(0xff4af699)],
-    barWidth: 8,
-    isStrokeCapRound: true,
-    dotData: FlDotData(
-      show: false,
-    ),
-    belowBarData: BarAreaData(
-      show: false,
-    ),
-  );
+        spots: [
+          FlSpot(1, 1),
+          FlSpot(3, 1.5),
+          FlSpot(5, 1.4),
+          FlSpot(7, 3.4),
+          FlSpot(10, 2),
+          FlSpot(12, 2.2),
+          FlSpot(13, 1.8),
+        ],
+        isCurved: true,
+        colors: [const Color(0xff4af699)],
+        barWidth: 8,
+        isStrokeCapRound: true,
+        dotData: FlDotData(
+          show: false,
+        ),
+        belowBarData: BarAreaData(
+          show: false,
+        ),
+      );
 
   LineChartBarData get lineChartBarData1_2 => LineChartBarData(
-    spots: [
-      FlSpot(1, 1),
-      FlSpot(3, 2.8),
-      FlSpot(7, 1.2),
-      FlSpot(10, 2.8),
-      FlSpot(12, 2.6),
-      FlSpot(13, 3.9),
-    ],
-    isCurved: true,
-    colors: [
-      const Color(0xffaa4cfc),
-    ],
-    barWidth: 8,
-    isStrokeCapRound: true,
-    dotData: FlDotData(
-      show: false,
-    ),
-    belowBarData: BarAreaData(show: false, colors: [
-      const Color(0x00aa4cfc),
-    ]),
-  );
+        spots: [
+          FlSpot(1, 1),
+          FlSpot(3, 2.8),
+          FlSpot(7, 1.2),
+          FlSpot(10, 2.8),
+          FlSpot(12, 2.6),
+          FlSpot(13, 3.9),
+        ],
+        isCurved: true,
+        colors: [
+          const Color(0xffaa4cfc),
+        ],
+        barWidth: 8,
+        isStrokeCapRound: true,
+        dotData: FlDotData(
+          show: false,
+        ),
+        belowBarData: BarAreaData(show: false, colors: [
+          const Color(0x00aa4cfc),
+        ]),
+      );
 
   LineChartBarData get lineChartBarData1_3 => LineChartBarData(
-    spots: [
-      FlSpot(1, 2.8),
-      FlSpot(3, 1.9),
-      FlSpot(6, 3),
-      FlSpot(10, 1.3),
-      FlSpot(13, 2.5),
-    ],
-    isCurved: true,
-    colors: const [
-      Color(0xff27b6fc),
-    ],
-    barWidth: 8,
-    isStrokeCapRound: true,
-    dotData: FlDotData(
-      show: false,
-    ),
-    belowBarData: BarAreaData(
-      show: false,
-    ),
-  );
+        spots: [
+          FlSpot(1, 2.8),
+          FlSpot(3, 1.9),
+          FlSpot(6, 3),
+          FlSpot(10, 1.3),
+          FlSpot(13, 2.5),
+        ],
+        isCurved: true,
+        colors: const [
+          Color(0xff27b6fc),
+        ],
+        barWidth: 8,
+        isStrokeCapRound: true,
+        dotData: FlDotData(
+          show: false,
+        ),
+        belowBarData: BarAreaData(
+          show: false,
+        ),
+      );
 }
 
 class LineChartSample1 extends StatefulWidget {

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -1,95 +1,16 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
-class LineChartSample1 extends StatefulWidget {
-  @override
-  State<StatefulWidget> createState() => LineChartSample1State();
-}
+class _LineChart extends StatelessWidget {
+  const _LineChart({required this.isShowingMainData});
 
-class LineChartSample1State extends State<LineChartSample1> {
-  late bool isShowingMainData;
-
-  @override
-  void initState() {
-    super.initState();
-    isShowingMainData = true;
-  }
+  final bool isShowingMainData;
 
   @override
   Widget build(BuildContext context) {
-    return AspectRatio(
-      aspectRatio: 1.23,
-      child: Container(
-        decoration: const BoxDecoration(
-          borderRadius: BorderRadius.all(Radius.circular(18)),
-          gradient: LinearGradient(
-            colors: [
-              Color(0xff2c274c),
-              Color(0xff46426c),
-            ],
-            begin: Alignment.bottomCenter,
-            end: Alignment.topCenter,
-          ),
-        ),
-        child: Stack(
-          children: <Widget>[
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
-                const SizedBox(
-                  height: 37,
-                ),
-                const Text(
-                  'Unfold Shop 2018',
-                  style: TextStyle(
-                    color: Color(0xff827daa),
-                    fontSize: 16,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(
-                  height: 4,
-                ),
-                const Text(
-                  'Monthly Sales',
-                  style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 32,
-                      fontWeight: FontWeight.bold,
-                      letterSpacing: 2),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(
-                  height: 37,
-                ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.only(right: 16.0, left: 6.0),
-                    child: LineChart(
-                      isShowingMainData ? sampleData1() : sampleData2(),
-                      swapAnimationDuration: const Duration(milliseconds: 250),
-                    ),
-                  ),
-                ),
-                const SizedBox(
-                  height: 10,
-                ),
-              ],
-            ),
-            IconButton(
-              icon: Icon(
-                Icons.refresh,
-                color: Colors.white.withOpacity(isShowingMainData ? 1.0 : 0.5),
-              ),
-              onPressed: () {
-                setState(() {
-                  isShowingMainData = !isShowingMainData;
-                });
-              },
-            )
-          ],
-        ),
-      ),
+    return LineChart(
+      isShowingMainData ? sampleData1() : sampleData2(),
+      swapAnimationDuration: const Duration(milliseconds: 250),
     );
   }
 
@@ -401,5 +322,95 @@ class LineChartSample1State extends State<LineChartSample1> {
         ),
       ),
     ];
+  }
+}
+
+class LineChartSample1 extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => LineChartSample1State();
+}
+
+class LineChartSample1State extends State<LineChartSample1> {
+  late bool isShowingMainData;
+
+  @override
+  void initState() {
+    super.initState();
+    isShowingMainData = true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1.23,
+      child: Container(
+        decoration: const BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(18)),
+          gradient: LinearGradient(
+            colors: [
+              Color(0xff2c274c),
+              Color(0xff46426c),
+            ],
+            begin: Alignment.bottomCenter,
+            end: Alignment.topCenter,
+          ),
+        ),
+        child: Stack(
+          children: <Widget>[
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                const SizedBox(
+                  height: 37,
+                ),
+                const Text(
+                  'Unfold Shop 2018',
+                  style: TextStyle(
+                    color: Color(0xff827daa),
+                    fontSize: 16,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(
+                  height: 4,
+                ),
+                const Text(
+                  'Monthly Sales',
+                  style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 32,
+                      fontWeight: FontWeight.bold,
+                      letterSpacing: 2),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(
+                  height: 37,
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 16.0, left: 6.0),
+                    child: _LineChart(isShowingMainData: isShowingMainData),
+                  ),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+              ],
+            ),
+            IconButton(
+              icon: Icon(
+                Icons.refresh,
+                color: Colors.white.withOpacity(isShowingMainData ? 1.0 : 0.5),
+              ),
+              onPressed: () {
+                setState(() {
+                  isShowingMainData = !isShowingMainData;
+                });
+              },
+            )
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -19,12 +19,26 @@ class _LineChart extends StatelessWidget {
         gridData: gridData,
         titlesData: titlesData1,
         borderData: borderData,
-        lineBarsData: linesBarData1,
+        lineBarsData: lineBarsData1,
         minX: 0,
         maxX: 14,
         maxY: 4,
         minY: 0,
       );
+
+  LineChartData sampleData2() {
+    return LineChartData(
+      lineTouchData: lineTouchData2,
+      gridData: gridData,
+      titlesData: titlesData2,
+      borderData: borderData,
+      lineBarsData: lineBarsData2,
+      minX: 0,
+      maxX: 14,
+      maxY: 6,
+      minY: 0,
+    );
+  }
 
   LineTouchData get lineTouchData1 => LineTouchData(
         touchTooltipData: LineTouchTooltipData(
@@ -53,25 +67,11 @@ class _LineChart extends StatelessWidget {
         ),
       );
 
-  List<LineChartBarData> get linesBarData1 => [
+  List<LineChartBarData> get lineBarsData1 => [
         lineChartBarData1_1,
         lineChartBarData1_2,
         lineChartBarData1_3,
       ];
-
-  LineChartData sampleData2() {
-    return LineChartData(
-      lineTouchData: lineTouchData2,
-      gridData: gridData,
-      titlesData: titlesData2,
-      borderData: borderData,
-      lineBarsData: linesBarData2,
-      minX: 0,
-      maxX: 14,
-      maxY: 6,
-      minY: 0,
-    );
-  }
 
   LineTouchData get lineTouchData2 => LineTouchData(
         enabled: false,
@@ -98,49 +98,45 @@ class _LineChart extends StatelessWidget {
         ),
       );
 
-  List<LineChartBarData> get linesBarData2 => [
+  List<LineChartBarData> get lineBarsData2 => [
         lineChartBarData2_1,
         lineChartBarData2_2,
         lineChartBarData2_3,
       ];
 
-  SideTitles leftTitles({required GetTitleFunction getTitles}) {
-    return SideTitles(
-      showTitles: true,
-      getTextStyles: (value) => const TextStyle(
-        color: Color(0xff75729e),
-        fontWeight: FontWeight.bold,
-        fontSize: 14,
-      ),
-      getTitles: getTitles,
-      margin: 8,
-      reservedSize: 30,
-    );
-  }
+  SideTitles leftTitles({required GetTitleFunction getTitles}) => SideTitles(
+        showTitles: true,
+        getTextStyles: (value) => const TextStyle(
+          color: Color(0xff75729e),
+          fontWeight: FontWeight.bold,
+          fontSize: 14,
+        ),
+        getTitles: getTitles,
+        margin: 8,
+        reservedSize: 30,
+      );
 
-  SideTitles bottomTitles() {
-    return SideTitles(
-      showTitles: true,
-      reservedSize: 22,
-      getTextStyles: (value) => const TextStyle(
-        color: Color(0xff72719b),
-        fontWeight: FontWeight.bold,
-        fontSize: 16,
-      ),
-      margin: 10,
-      getTitles: (value) {
-        switch (value.toInt()) {
-          case 2:
-            return 'SEPT';
-          case 7:
-            return 'OCT';
-          case 12:
-            return 'DEC';
-        }
-        return '';
-      },
-    );
-  }
+  SideTitles bottomTitles() => SideTitles(
+        showTitles: true,
+        reservedSize: 22,
+        getTextStyles: (value) => const TextStyle(
+          color: Color(0xff72719b),
+          fontWeight: FontWeight.bold,
+          fontSize: 16,
+        ),
+        margin: 10,
+        getTitles: (value) {
+          switch (value.toInt()) {
+            case 2:
+              return 'SEPT';
+            case 7:
+              return 'OCT';
+            case 12:
+              return 'DEC';
+          }
+          return '';
+        },
+      );
 
   FlGridData get gridData => FlGridData(
         show: false,

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -16,17 +16,29 @@ class _LineChart extends StatelessWidget {
 
   LineChartData sampleData1() {
     return LineChartData(
-      lineTouchData: LineTouchData(
-        touchTooltipData: LineTouchTooltipData(
-          tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
-        ),
-        touchCallback: (LineTouchResponse touchResponse) {},
-        handleBuiltInTouches: true,
+      lineTouchData: lineTouchData1(),
+      gridData: FlGridData(show: false),
+      titlesData: titlesData1(),
+      borderData: borderData(),
+      minX: 0,
+      maxX: 14,
+      maxY: 4,
+      minY: 0,
+      lineBarsData: linesBarData1(),
+    );
+  }
+
+  LineTouchData lineTouchData1() {
+    return LineTouchData(
+      touchTooltipData: LineTouchTooltipData(
+        tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
       ),
-      gridData: FlGridData(
-        show: false,
-      ),
-      titlesData: FlTitlesData(
+      touchCallback: (LineTouchResponse touchResponse) {},
+      handleBuiltInTouches: true,
+    );
+  }
+
+  FlTitlesData titlesData1() => FlTitlesData(
         bottomTitles: bottomTitles(),
         leftTitles: leftTitles(
           getTitles: (value) {
@@ -43,15 +55,7 @@ class _LineChart extends StatelessWidget {
             return '';
           },
         ),
-      ),
-      borderData: borderData(),
-      minX: 0,
-      maxX: 14,
-      maxY: 4,
-      minY: 0,
-      lineBarsData: linesBarData1(),
-    );
-  }
+      );
 
   List<LineChartBarData> linesBarData1() {
     final lineChartBarData1 = LineChartBarData(
@@ -66,7 +70,7 @@ class _LineChart extends StatelessWidget {
       ],
       isCurved: true,
       colors: [
-        const Color(0xff4af699),
+        const Color(0xff4af699)
       ],
       barWidth: 8,
       isStrokeCapRound: true,

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -27,27 +27,7 @@ class _LineChart extends StatelessWidget {
         show: false,
       ),
       titlesData: FlTitlesData(
-        bottomTitles: SideTitles(
-          showTitles: true,
-          reservedSize: 22,
-          getTextStyles: (value) => const TextStyle(
-            color: Color(0xff72719b),
-            fontWeight: FontWeight.bold,
-            fontSize: 16,
-          ),
-          margin: 10,
-          getTitles: (value) {
-            switch (value.toInt()) {
-              case 2:
-                return 'SEPT';
-              case 7:
-                return 'OCT';
-              case 12:
-                return 'DEC';
-            }
-            return '';
-          },
-        ),
+        bottomTitles: bottomTitles(),
         leftTitles: SideTitles(
           showTitles: true,
           getTextStyles: (value) => const TextStyle(
@@ -181,27 +161,7 @@ class _LineChart extends StatelessWidget {
         show: false,
       ),
       titlesData: FlTitlesData(
-        bottomTitles: SideTitles(
-          showTitles: true,
-          reservedSize: 22,
-          getTextStyles: (value) => const TextStyle(
-            color: Color(0xff72719b),
-            fontWeight: FontWeight.bold,
-            fontSize: 16,
-          ),
-          margin: 10,
-          getTitles: (value) {
-            switch (value.toInt()) {
-              case 2:
-                return 'SEPT';
-              case 7:
-                return 'OCT';
-              case 12:
-                return 'DEC';
-            }
-            return '';
-          },
-        ),
+        bottomTitles: bottomTitles(),
         leftTitles: SideTitles(
           showTitles: true,
           getTextStyles: (value) => const TextStyle(
@@ -322,6 +282,30 @@ class _LineChart extends StatelessWidget {
         ),
       ),
     ];
+  }
+
+  SideTitles bottomTitles() {
+    return SideTitles(
+      showTitles: true,
+      reservedSize: 22,
+      getTextStyles: (value) => const TextStyle(
+        color: Color(0xff72719b),
+        fontWeight: FontWeight.bold,
+        fontSize: 16,
+      ),
+      margin: 10,
+      getTitles: (value) {
+        switch (value.toInt()) {
+          case 2:
+            return 'SEPT';
+          case 7:
+            return 'OCT';
+          case 12:
+            return 'DEC';
+        }
+        return '';
+      },
+    );
   }
 }
 

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -44,24 +44,7 @@ class _LineChart extends StatelessWidget {
           },
         ),
       ),
-      borderData: FlBorderData(
-        show: true,
-        border: const Border(
-          bottom: BorderSide(
-            color: Color(0xff4e4965),
-            width: 4,
-          ),
-          left: BorderSide(
-            color: Colors.transparent,
-          ),
-          right: BorderSide(
-            color: Colors.transparent,
-          ),
-          top: BorderSide(
-            color: Colors.transparent,
-          ),
-        ),
-      ),
+      borderData: borderData(),
       minX: 0,
       maxX: 14,
       maxY: 4,
@@ -172,23 +155,7 @@ class _LineChart extends StatelessWidget {
           },
         ),
       ),
-      borderData: FlBorderData(
-          show: true,
-          border: const Border(
-            bottom: BorderSide(
-              color: Color(0xff4e4965),
-              width: 4,
-            ),
-            left: BorderSide(
-              color: Colors.transparent,
-            ),
-            right: BorderSide(
-              color: Colors.transparent,
-            ),
-            top: BorderSide(
-              color: Colors.transparent,
-            ),
-          )),
+      borderData: borderData(),
       minX: 0,
       maxX: 14,
       maxY: 6,
@@ -303,6 +270,27 @@ class _LineChart extends StatelessWidget {
         }
         return '';
       },
+    );
+  }
+
+  FlBorderData borderData() {
+    return FlBorderData(
+      show: true,
+      border: const Border(
+        bottom: BorderSide(
+          color: Color(0xff4e4965),
+          width: 4,
+        ),
+        left: BorderSide(
+          color: Colors.transparent,
+        ),
+        right: BorderSide(
+          color: Colors.transparent,
+        ),
+        top: BorderSide(
+          color: Colors.transparent,
+        ),
+      ),
     );
   }
 }

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -61,11 +61,23 @@ class _LineChart extends StatelessWidget {
 
   LineChartData sampleData2() {
     return LineChartData(
-      lineTouchData: LineTouchData(
-        enabled: false,
-      ),
+      lineTouchData: lineTouchData2,
       gridData: gridData,
-      titlesData: FlTitlesData(
+      titlesData: titlesData2,
+      borderData: borderData,
+      lineBarsData: linesBarData2,
+      minX: 0,
+      maxX: 14,
+      maxY: 6,
+      minY: 0,
+    );
+  }
+
+  LineTouchData get lineTouchData2 => LineTouchData(
+        enabled: false,
+      );
+
+  FlTitlesData get titlesData2 => FlTitlesData(
         bottomTitles: bottomTitles(),
         leftTitles: leftTitles(
           getTitles: (value) {
@@ -84,86 +96,13 @@ class _LineChart extends StatelessWidget {
             return '';
           },
         ),
-      ),
-      borderData: borderData,
-      minX: 0,
-      maxX: 14,
-      maxY: 6,
-      minY: 0,
-      lineBarsData: linesBarData2(),
-    );
-  }
+      );
 
-  List<LineChartBarData> linesBarData2() {
-    return [
-      LineChartBarData(
-        spots: [
-          FlSpot(1, 1),
-          FlSpot(3, 4),
-          FlSpot(5, 1.8),
-          FlSpot(7, 5),
-          FlSpot(10, 2),
-          FlSpot(12, 2.2),
-          FlSpot(13, 1.8),
-        ],
-        isCurved: true,
-        curveSmoothness: 0,
-        colors: const [
-          Color(0x444af699),
-        ],
-        barWidth: 4,
-        isStrokeCapRound: true,
-        dotData: FlDotData(
-          show: false,
-        ),
-        belowBarData: BarAreaData(
-          show: false,
-        ),
-      ),
-      LineChartBarData(
-        spots: [
-          FlSpot(1, 1),
-          FlSpot(3, 2.8),
-          FlSpot(7, 1.2),
-          FlSpot(10, 2.8),
-          FlSpot(12, 2.6),
-          FlSpot(13, 3.9),
-        ],
-        isCurved: true,
-        colors: const [
-          Color(0x99aa4cfc),
-        ],
-        barWidth: 4,
-        isStrokeCapRound: true,
-        dotData: FlDotData(
-          show: false,
-        ),
-        belowBarData: BarAreaData(show: true, colors: [
-          const Color(0x33aa4cfc),
-        ]),
-      ),
-      LineChartBarData(
-        spots: [
-          FlSpot(1, 3.8),
-          FlSpot(3, 1.9),
-          FlSpot(6, 5),
-          FlSpot(10, 3.3),
-          FlSpot(13, 4.5),
-        ],
-        isCurved: true,
-        curveSmoothness: 0,
-        colors: const [
-          Color(0x4427b6fc),
-        ],
-        barWidth: 2,
-        isStrokeCapRound: true,
-        dotData: FlDotData(show: true),
-        belowBarData: BarAreaData(
-          show: false,
-        ),
-      ),
-    ];
-  }
+  List<LineChartBarData> get linesBarData2 => [
+        lineChartBarData2_1,
+        lineChartBarData2_2,
+        lineChartBarData2_3,
+      ];
 
   SideTitles leftTitles({required GetTitleFunction getTitles}) {
     return SideTitles(
@@ -288,6 +227,75 @@ class _LineChart extends StatelessWidget {
         dotData: FlDotData(
           show: false,
         ),
+        belowBarData: BarAreaData(
+          show: false,
+        ),
+      );
+
+  LineChartBarData get lineChartBarData2_1 => LineChartBarData(
+        spots: [
+          FlSpot(1, 1),
+          FlSpot(3, 4),
+          FlSpot(5, 1.8),
+          FlSpot(7, 5),
+          FlSpot(10, 2),
+          FlSpot(12, 2.2),
+          FlSpot(13, 1.8),
+        ],
+        isCurved: true,
+        curveSmoothness: 0,
+        colors: const [
+          Color(0x444af699),
+        ],
+        barWidth: 4,
+        isStrokeCapRound: true,
+        dotData: FlDotData(
+          show: false,
+        ),
+        belowBarData: BarAreaData(
+          show: false,
+        ),
+      );
+
+  LineChartBarData get lineChartBarData2_2 => LineChartBarData(
+        spots: [
+          FlSpot(1, 1),
+          FlSpot(3, 2.8),
+          FlSpot(7, 1.2),
+          FlSpot(10, 2.8),
+          FlSpot(12, 2.6),
+          FlSpot(13, 3.9),
+        ],
+        isCurved: true,
+        colors: const [
+          Color(0x99aa4cfc),
+        ],
+        barWidth: 4,
+        isStrokeCapRound: true,
+        dotData: FlDotData(
+          show: false,
+        ),
+        belowBarData: BarAreaData(show: true, colors: [
+          const Color(0x33aa4cfc),
+        ]),
+      );
+
+  LineChartBarData get lineChartBarData2_3 => LineChartBarData(
+        spots: [
+          FlSpot(1, 3.8),
+          FlSpot(3, 1.9),
+          FlSpot(6, 5),
+          FlSpot(10, 3.3),
+          FlSpot(13, 4.5),
+        ],
+        isCurved: true,
+        curveSmoothness: 0,
+        colors: const [
+          Color(0x4427b6fc),
+        ],
+        barWidth: 2,
+        isStrokeCapRound: true,
+        dotData: FlDotData(show: true),
         belowBarData: BarAreaData(
           show: false,
         ),

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -9,7 +9,7 @@ class _LineChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LineChart(
-      isShowingMainData ? sampleData1 : sampleData2(),
+      isShowingMainData ? sampleData1 : sampleData2,
       swapAnimationDuration: const Duration(milliseconds: 250),
     );
   }
@@ -26,30 +26,28 @@ class _LineChart extends StatelessWidget {
         minY: 0,
       );
 
-  LineChartData sampleData2() {
-    return LineChartData(
-      lineTouchData: lineTouchData2,
-      gridData: gridData,
-      titlesData: titlesData2,
-      borderData: borderData,
-      lineBarsData: lineBarsData2,
-      minX: 0,
-      maxX: 14,
-      maxY: 6,
-      minY: 0,
-    );
-  }
+  LineChartData get sampleData2 => LineChartData(
+        lineTouchData: lineTouchData2,
+        gridData: gridData,
+        titlesData: titlesData2,
+        borderData: borderData,
+        lineBarsData: lineBarsData2,
+        minX: 0,
+        maxX: 14,
+        maxY: 6,
+        minY: 0,
+      );
 
   LineTouchData get lineTouchData1 => LineTouchData(
+        touchCallback: (LineTouchResponse touchResponse) {},
+        handleBuiltInTouches: true,
         touchTooltipData: LineTouchTooltipData(
           tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
         ),
-        touchCallback: (LineTouchResponse touchResponse) {},
-        handleBuiltInTouches: true,
       );
 
   FlTitlesData get titlesData1 => FlTitlesData(
-        bottomTitles: bottomTitles(),
+        bottomTitles: bottomTitles,
         leftTitles: leftTitles(
           getTitles: (value) {
             switch (value.toInt()) {
@@ -78,7 +76,7 @@ class _LineChart extends StatelessWidget {
       );
 
   FlTitlesData get titlesData2 => FlTitlesData(
-        bottomTitles: bottomTitles(),
+        bottomTitles: bottomTitles,
         leftTitles: leftTitles(
           getTitles: (value) {
             switch (value.toInt()) {
@@ -105,26 +103,26 @@ class _LineChart extends StatelessWidget {
       ];
 
   SideTitles leftTitles({required GetTitleFunction getTitles}) => SideTitles(
+        getTitles: getTitles,
         showTitles: true,
+        margin: 8,
+        reservedSize: 30,
         getTextStyles: (value) => const TextStyle(
           color: Color(0xff75729e),
           fontWeight: FontWeight.bold,
           fontSize: 14,
         ),
-        getTitles: getTitles,
-        margin: 8,
-        reservedSize: 30,
       );
 
-  SideTitles bottomTitles() => SideTitles(
+  SideTitles get bottomTitles => SideTitles(
         showTitles: true,
         reservedSize: 22,
+        margin: 10,
         getTextStyles: (value) => const TextStyle(
           color: Color(0xff72719b),
           fontWeight: FontWeight.bold,
           fontSize: 16,
         ),
-        margin: 10,
         getTitles: (value) {
           switch (value.toInt()) {
             case 2:
@@ -138,30 +136,25 @@ class _LineChart extends StatelessWidget {
         },
       );
 
-  FlGridData get gridData => FlGridData(
-        show: false,
-      );
+  FlGridData get gridData => FlGridData(show: false);
 
   FlBorderData get borderData => FlBorderData(
         show: true,
         border: const Border(
-          bottom: BorderSide(
-            color: Color(0xff4e4965),
-            width: 4,
-          ),
-          left: BorderSide(
-            color: Colors.transparent,
-          ),
-          right: BorderSide(
-            color: Colors.transparent,
-          ),
-          top: BorderSide(
-            color: Colors.transparent,
-          ),
+          bottom: BorderSide(color: Color(0xff4e4965), width: 4),
+          left: BorderSide(color: Colors.transparent),
+          right: BorderSide(color: Colors.transparent),
+          top: BorderSide(color: Colors.transparent),
         ),
       );
 
   LineChartBarData get lineChartBarData1_1 => LineChartBarData(
+        isCurved: true,
+        colors: [const Color(0xff4af699)],
+        barWidth: 8,
+        isStrokeCapRound: true,
+        dotData: FlDotData(show: false),
+        belowBarData: BarAreaData(show: false),
         spots: [
           FlSpot(1, 1),
           FlSpot(3, 1.5),
@@ -171,19 +164,17 @@ class _LineChart extends StatelessWidget {
           FlSpot(12, 2.2),
           FlSpot(13, 1.8),
         ],
-        isCurved: true,
-        colors: [const Color(0xff4af699)],
-        barWidth: 8,
-        isStrokeCapRound: true,
-        dotData: FlDotData(
-          show: false,
-        ),
-        belowBarData: BarAreaData(
-          show: false,
-        ),
       );
 
   LineChartBarData get lineChartBarData1_2 => LineChartBarData(
+        isCurved: true,
+        colors: [const Color(0xffaa4cfc)],
+        barWidth: 8,
+        isStrokeCapRound: true,
+        dotData: FlDotData(show: false),
+        belowBarData: BarAreaData(show: false, colors: [
+          const Color(0x00aa4cfc),
+        ]),
         spots: [
           FlSpot(1, 1),
           FlSpot(3, 2.8),
@@ -192,21 +183,15 @@ class _LineChart extends StatelessWidget {
           FlSpot(12, 2.6),
           FlSpot(13, 3.9),
         ],
-        isCurved: true,
-        colors: [
-          const Color(0xffaa4cfc),
-        ],
-        barWidth: 8,
-        isStrokeCapRound: true,
-        dotData: FlDotData(
-          show: false,
-        ),
-        belowBarData: BarAreaData(show: false, colors: [
-          const Color(0x00aa4cfc),
-        ]),
       );
 
   LineChartBarData get lineChartBarData1_3 => LineChartBarData(
+        isCurved: true,
+        colors: const [Color(0xff27b6fc)],
+        barWidth: 8,
+        isStrokeCapRound: true,
+        dotData: FlDotData(show: false),
+        belowBarData: BarAreaData(show: false),
         spots: [
           FlSpot(1, 2.8),
           FlSpot(3, 1.9),
@@ -214,21 +199,16 @@ class _LineChart extends StatelessWidget {
           FlSpot(10, 1.3),
           FlSpot(13, 2.5),
         ],
-        isCurved: true,
-        colors: const [
-          Color(0xff27b6fc),
-        ],
-        barWidth: 8,
-        isStrokeCapRound: true,
-        dotData: FlDotData(
-          show: false,
-        ),
-        belowBarData: BarAreaData(
-          show: false,
-        ),
       );
 
   LineChartBarData get lineChartBarData2_1 => LineChartBarData(
+        isCurved: true,
+        curveSmoothness: 0,
+        colors: const [Color(0x444af699)],
+        barWidth: 4,
+        isStrokeCapRound: true,
+        dotData: FlDotData(show: false),
+        belowBarData: BarAreaData(show: false),
         spots: [
           FlSpot(1, 1),
           FlSpot(3, 4),
@@ -238,22 +218,20 @@ class _LineChart extends StatelessWidget {
           FlSpot(12, 2.2),
           FlSpot(13, 1.8),
         ],
-        isCurved: true,
-        curveSmoothness: 0,
-        colors: const [
-          Color(0x444af699),
-        ],
-        barWidth: 4,
-        isStrokeCapRound: true,
-        dotData: FlDotData(
-          show: false,
-        ),
-        belowBarData: BarAreaData(
-          show: false,
-        ),
       );
 
   LineChartBarData get lineChartBarData2_2 => LineChartBarData(
+        isCurved: true,
+        colors: const [Color(0x99aa4cfc)],
+        barWidth: 4,
+        isStrokeCapRound: true,
+        dotData: FlDotData(show: false),
+        belowBarData: BarAreaData(
+          show: true,
+          colors: [
+            const Color(0x33aa4cfc),
+          ],
+        ),
         spots: [
           FlSpot(1, 1),
           FlSpot(3, 2.8),
@@ -262,21 +240,16 @@ class _LineChart extends StatelessWidget {
           FlSpot(12, 2.6),
           FlSpot(13, 3.9),
         ],
-        isCurved: true,
-        colors: const [
-          Color(0x99aa4cfc),
-        ],
-        barWidth: 4,
-        isStrokeCapRound: true,
-        dotData: FlDotData(
-          show: false,
-        ),
-        belowBarData: BarAreaData(show: true, colors: [
-          const Color(0x33aa4cfc),
-        ]),
       );
 
   LineChartBarData get lineChartBarData2_3 => LineChartBarData(
+        isCurved: true,
+        curveSmoothness: 0,
+        colors: const [Color(0x4427b6fc)],
+        barWidth: 2,
+        isStrokeCapRound: true,
+        dotData: FlDotData(show: true),
+        belowBarData: BarAreaData(show: false),
         spots: [
           FlSpot(1, 3.8),
           FlSpot(3, 1.9),
@@ -284,17 +257,6 @@ class _LineChart extends StatelessWidget {
           FlSpot(10, 3.3),
           FlSpot(13, 4.5),
         ],
-        isCurved: true,
-        curveSmoothness: 0,
-        colors: const [
-          Color(0x4427b6fc),
-        ],
-        barWidth: 2,
-        isStrokeCapRound: true,
-        dotData: FlDotData(show: true),
-        belowBarData: BarAreaData(
-          show: false,
-        ),
       );
 }
 

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -20,23 +20,21 @@ class _LineChart extends StatelessWidget {
       gridData: FlGridData(show: false),
       titlesData: titlesData1(),
       borderData: borderData(),
+      lineBarsData: linesBarData1(),
       minX: 0,
       maxX: 14,
       maxY: 4,
       minY: 0,
-      lineBarsData: linesBarData1(),
     );
   }
 
-  LineTouchData lineTouchData1() {
-    return LineTouchData(
-      touchTooltipData: LineTouchTooltipData(
-        tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
-      ),
-      touchCallback: (LineTouchResponse touchResponse) {},
-      handleBuiltInTouches: true,
-    );
-  }
+  LineTouchData lineTouchData1() => LineTouchData(
+        touchTooltipData: LineTouchTooltipData(
+          tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
+        ),
+        touchCallback: (LineTouchResponse touchResponse) {},
+        handleBuiltInTouches: true,
+      );
 
   FlTitlesData titlesData1() => FlTitlesData(
         bottomTitles: bottomTitles(),
@@ -57,79 +55,11 @@ class _LineChart extends StatelessWidget {
         ),
       );
 
-  List<LineChartBarData> linesBarData1() {
-    final lineChartBarData1 = LineChartBarData(
-      spots: [
-        FlSpot(1, 1),
-        FlSpot(3, 1.5),
-        FlSpot(5, 1.4),
-        FlSpot(7, 3.4),
-        FlSpot(10, 2),
-        FlSpot(12, 2.2),
-        FlSpot(13, 1.8),
-      ],
-      isCurved: true,
-      colors: [
-        const Color(0xff4af699)
-      ],
-      barWidth: 8,
-      isStrokeCapRound: true,
-      dotData: FlDotData(
-        show: false,
-      ),
-      belowBarData: BarAreaData(
-        show: false,
-      ),
-    );
-    final lineChartBarData2 = LineChartBarData(
-      spots: [
-        FlSpot(1, 1),
-        FlSpot(3, 2.8),
-        FlSpot(7, 1.2),
-        FlSpot(10, 2.8),
-        FlSpot(12, 2.6),
-        FlSpot(13, 3.9),
-      ],
-      isCurved: true,
-      colors: [
-        const Color(0xffaa4cfc),
-      ],
-      barWidth: 8,
-      isStrokeCapRound: true,
-      dotData: FlDotData(
-        show: false,
-      ),
-      belowBarData: BarAreaData(show: false, colors: [
-        const Color(0x00aa4cfc),
-      ]),
-    );
-    final lineChartBarData3 = LineChartBarData(
-      spots: [
-        FlSpot(1, 2.8),
-        FlSpot(3, 1.9),
-        FlSpot(6, 3),
-        FlSpot(10, 1.3),
-        FlSpot(13, 2.5),
-      ],
-      isCurved: true,
-      colors: const [
-        Color(0xff27b6fc),
-      ],
-      barWidth: 8,
-      isStrokeCapRound: true,
-      dotData: FlDotData(
-        show: false,
-      ),
-      belowBarData: BarAreaData(
-        show: false,
-      ),
-    );
-    return [
-      lineChartBarData1,
-      lineChartBarData2,
-      lineChartBarData3,
-    ];
-  }
+  List<LineChartBarData> linesBarData1() => [
+    lineChartBarData1_1,
+    lineChartBarData1_2,
+    lineChartBarData1_3,
+  ];
 
   LineChartData sampleData2() {
     return LineChartData(
@@ -297,6 +227,73 @@ class _LineChart extends StatelessWidget {
       ),
     );
   }
+
+  LineChartBarData get lineChartBarData1_1 => LineChartBarData(
+    spots: [
+      FlSpot(1, 1),
+      FlSpot(3, 1.5),
+      FlSpot(5, 1.4),
+      FlSpot(7, 3.4),
+      FlSpot(10, 2),
+      FlSpot(12, 2.2),
+      FlSpot(13, 1.8),
+    ],
+    isCurved: true,
+    colors: [const Color(0xff4af699)],
+    barWidth: 8,
+    isStrokeCapRound: true,
+    dotData: FlDotData(
+      show: false,
+    ),
+    belowBarData: BarAreaData(
+      show: false,
+    ),
+  );
+
+  LineChartBarData get lineChartBarData1_2 => LineChartBarData(
+    spots: [
+      FlSpot(1, 1),
+      FlSpot(3, 2.8),
+      FlSpot(7, 1.2),
+      FlSpot(10, 2.8),
+      FlSpot(12, 2.6),
+      FlSpot(13, 3.9),
+    ],
+    isCurved: true,
+    colors: [
+      const Color(0xffaa4cfc),
+    ],
+    barWidth: 8,
+    isStrokeCapRound: true,
+    dotData: FlDotData(
+      show: false,
+    ),
+    belowBarData: BarAreaData(show: false, colors: [
+      const Color(0x00aa4cfc),
+    ]),
+  );
+
+  LineChartBarData get lineChartBarData1_3 => LineChartBarData(
+    spots: [
+      FlSpot(1, 2.8),
+      FlSpot(3, 1.9),
+      FlSpot(6, 3),
+      FlSpot(10, 1.3),
+      FlSpot(13, 2.5),
+    ],
+    isCurved: true,
+    colors: const [
+      Color(0xff27b6fc),
+    ],
+    barWidth: 8,
+    isStrokeCapRound: true,
+    dotData: FlDotData(
+      show: false,
+    ),
+    belowBarData: BarAreaData(
+      show: false,
+    ),
+  );
 }
 
 class LineChartSample1 extends StatefulWidget {

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -16,7 +16,7 @@ class _LineChart extends StatelessWidget {
 
   LineChartData get sampleData1 => LineChartData(
         lineTouchData: lineTouchData1,
-        gridData: FlGridData(show: false),
+        gridData: gridData,
         titlesData: titlesData1,
         borderData: borderData,
         lineBarsData: linesBarData1,
@@ -64,9 +64,7 @@ class _LineChart extends StatelessWidget {
       lineTouchData: LineTouchData(
         enabled: false,
       ),
-      gridData: FlGridData(
-        show: false,
-      ),
+      gridData: gridData,
       titlesData: FlTitlesData(
         bottomTitles: bottomTitles(),
         leftTitles: leftTitles(
@@ -204,6 +202,10 @@ class _LineChart extends StatelessWidget {
       },
     );
   }
+
+  FlGridData get gridData => FlGridData(
+        show: false,
+      );
 
   FlBorderData get borderData => FlBorderData(
         show: true,


### PR DESCRIPTION
This library is fantastic.  But I thought the samples were room for improvement because there were many classes and arguments in this library.

First, that developers who use this library should want to know about this library.
So they don't have to see codes unrelated to this library(For example, StatefulWidget, AspectRatio, and so on).
In other words, I think the codes about this library are better if on the top of the sample.

Then, I think the sample codes are better if divided into smaller functions because this library can do many excellent jobs.

I tried to refactor it. I think it's easier to read than before. What do you think?