### PR TITLE
Fix pie chart stroke problem when adding space between sections (using new approach), #818.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **BUGFIX** Fix BarChart empty groups state error, #797.
 * **BUGFIX** Fix drawTooltipOnTop direction minor bug, #815.
 * **BUGFIX** Fix section with zero value problem in PieChart (disabled animation on changing value to zero and from zero), #817
+* **BUGFIX** Fix pie chart stroke problem when adding space between sections, #818.
 * **IMPROVEMENT** Fix interval below one, #811
 
 ## 0.40.2

--- a/lib/src/chart/base/line.dart
+++ b/lib/src/chart/base/line.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/painting.dart';
+import 'dart:math' as math;
 
 /// Describes a line model (contains [from], and end [to])
 class Line {
@@ -9,4 +10,24 @@ class Line {
   final Offset to;
 
   Line(this.from, this.to);
+
+  /// Returns the length of line
+  double magnitude() {
+    final diff = to - from;
+    final dx = diff.dx;
+    final dy = diff.dy;
+    return math.sqrt(dx * dx + dy * dy);
+  }
+
+  /// Returns angle of the line in radians
+  double direction() {
+    final diff = to - from;
+    return math.atan(diff.dy / diff.dx);
+  }
+
+  /// Returns the line in magnitude of 1.0
+  Offset normalize() {
+    final diffOffset = to - from;
+    return diffOffset * (1.0 / magnitude());
+  }
 }

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -12,10 +12,7 @@ import 'pie_chart_data.dart';
 
 /// Paints [PieChartData] in the canvas, it can be used in a [CustomPainter]
 class PieChartPainter extends BaseChartPainter<PieChartData> {
-  late Paint _sectionPaint,
-      _sectionStrokePaint,
-      _sectionsSpaceClearPaint,
-      _centerSpacePaint;
+  late Paint _sectionPaint, _sectionStrokePaint, _centerSpacePaint;
 
   /// Paints [data] into canvas, it is the animating [PieChartData],
   /// [targetData] is the animation's target and remains the same
@@ -29,11 +26,6 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     _sectionPaint = Paint()..style = PaintingStyle.stroke;
 
     _sectionStrokePaint = Paint()..style = PaintingStyle.stroke;
-
-    _sectionsSpaceClearPaint = Paint()
-      ..style = PaintingStyle.fill
-      ..color = const Color(0x00000000)
-      ..blendMode = BlendMode.srcOut;
 
     _centerSpacePaint = Paint()..style = PaintingStyle.fill;
   }
@@ -82,15 +74,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     PaintHolder<PieChartData> holder,
   ) {
     final data = holder.data;
-    final shouldDrawSeparators =
-        data.sectionsSpace != 0 && data.sections.length > 1;
-
     final viewSize = canvasWrapper.size;
-
-    if (shouldDrawSeparators) {
-      canvasWrapper.saveLayer(
-          Rect.fromLTWH(0, 0, viewSize.width, viewSize.height), Paint());
-    }
 
     final center = Offset(viewSize.width / 2, viewSize.height / 2);
 
@@ -99,16 +83,6 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     for (var i = 0; i < data.sections.length; i++) {
       final section = data.sections[i];
       final sectionDegree = sectionsAngle[i];
-
-      final sectionRadiusRect = Rect.fromCircle(
-        center: center,
-        radius: centerRadius + section.radius,
-      );
-
-      final centerRadiusRect = Rect.fromCircle(
-        center: center,
-        radius: centerRadius,
-      );
 
       if (sectionDegree == 360) {
         _sectionPaint.color = section.color;
@@ -119,62 +93,58 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         return;
       }
 
-      final startRadians = radians(tempAngle);
-      final sweepRadians = radians(sectionDegree);
-      final endRadians = startRadians + sweepRadians;
+      var sectionPath = _generateSectionPath(
+        section,
+        data.sectionsSpace,
+        tempAngle,
+        sectionDegree,
+        center,
+        centerRadius,
+      );
 
-      final startLineDirection =
-          Offset(math.cos(startRadians), math.sin(startRadians));
-      final startLineFrom = center + startLineDirection * centerRadius;
-      final startLineTo = startLineFrom + startLineDirection * section.radius;
-      final startLine = Line(startLineFrom, startLineTo);
-
-      final endLineDirection =
-          Offset(math.cos(endRadians), math.sin(endRadians));
-      final endLineFrom = center + endLineDirection * centerRadius;
-      final endLineTo = endLineFrom + endLineDirection * section.radius;
-      final endLine = Line(endLineFrom, endLineTo);
-
-      final sectionPath = _generateSectionPath(startLine, endLine, startRadians,
-          endRadians, sectionRadiusRect, centerRadiusRect);
-
-      _sectionPaint.color = section.color;
-      _sectionPaint.style = PaintingStyle.fill;
-      canvasWrapper.drawPath(sectionPath, _sectionPaint);
-
-      if (section.borderSide.width != 0.0 &&
-          section.borderSide.color.opacity != 0.0) {
-        canvasWrapper.saveLayer(
-            Rect.fromLTWH(0, 0, viewSize.width, viewSize.height), Paint());
-        canvasWrapper.clipPath(sectionPath);
-
-        _sectionStrokePaint.strokeWidth = section.borderSide.width * 2;
-        _sectionStrokePaint.color = section.borderSide.color;
-        canvasWrapper.drawPath(
-          sectionPath,
-          _sectionStrokePaint,
-        );
-        canvasWrapper.restore();
-      }
+      _drawSection(section, sectionPath, canvasWrapper);
+      _drawSectionStroke(section, sectionPath, canvasWrapper, viewSize);
       tempAngle += sectionDegree;
-    }
-
-    if (shouldDrawSeparators) {
-      _removeSectionsSpace(canvasWrapper, holder, centerRadius);
     }
   }
 
   /// Generates a path around a section
   Path _generateSectionPath(
-    Line startLine,
-    Line endLine,
-    double startRadians,
-    double endRadians,
-    Rect sectionRadiusRect,
-    Rect centerRadiusRect,
+    PieChartSectionData section,
+    double sectionSpace,
+    double tempAngle,
+    double sectionDegree,
+    Offset center,
+    double centerRadius,
   ) {
-    final sweepRadians = endRadians - startRadians;
-    return Path()
+    final sectionRadiusRect = Rect.fromCircle(
+      center: center,
+      radius: centerRadius + section.radius,
+    );
+
+    final centerRadiusRect = Rect.fromCircle(
+      center: center,
+      radius: centerRadius,
+    );
+
+    final startRadians = radians(tempAngle);
+    final sweepRadians = radians(sectionDegree);
+    final endRadians = startRadians + sweepRadians;
+
+    final startLineDirection =
+        Offset(math.cos(startRadians), math.sin(startRadians));
+
+    final startLineFrom = center + startLineDirection * centerRadius;
+    final startLineTo = startLineFrom + startLineDirection * section.radius;
+    final startLine = Line(startLineFrom, startLineTo);
+
+    final endLineDirection = Offset(math.cos(endRadians), math.sin(endRadians));
+
+    final endLineFrom = center + endLineDirection * centerRadius;
+    final endLineTo = endLineFrom + endLineDirection * section.radius;
+    final endLine = Line(endLineFrom, endLineTo);
+
+    var sectionPath = Path()
       ..moveTo(startLine.from.dx, startLine.from.dy)
       ..lineTo(startLine.to.dx, startLine.to.dy)
       ..arcTo(sectionRadiusRect, startRadians, sweepRadians, false)
@@ -182,50 +152,91 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
       ..arcTo(centerRadiusRect, endRadians, -sweepRadians, false)
       ..moveTo(startLine.from.dx, startLine.from.dy)
       ..close();
+
+    /// Subtract section space from the sectionPath
+    if (sectionSpace != 0) {
+      final startLineSeparatorPath = _createRectPathAroundLine(
+          Line(startLineFrom, startLineTo), sectionSpace);
+      sectionPath = Path.combine(
+          PathOperation.difference, sectionPath, startLineSeparatorPath);
+
+      final endLineSeparatorPath =
+          _createRectPathAroundLine(Line(endLineFrom, endLineTo), sectionSpace);
+      sectionPath = Path.combine(
+          PathOperation.difference, sectionPath, endLineSeparatorPath);
+    }
+
+    return sectionPath;
   }
 
-  /// firstly the sections draw close to eachOther without any space,
-  /// then here we clear a line with given [PieChartData.width]
-  void _removeSectionsSpace(
-    CanvasWrapper canvasWrapper,
-    PaintHolder<PieChartData> holder,
-    double centerRadius,
-  ) {
-    final data = holder.data;
-    final viewSize = canvasWrapper.size;
-    const extraLineSize = 1;
-    final center = Offset(viewSize.width / 2, viewSize.height / 2);
+  /// Creates a rect around a narrow line
+  Path _createRectPathAroundLine(Line line, double width) {
+    width = width / 2;
+    final normalized = line.normalize();
 
-    var tempAngle = data.startDegreeOffset;
-    data.sections.asMap().forEach((index, section) {
-      final previousIndex = index == 0 ? data.sections.length - 1 : index - 1;
-      final previousSection = data.sections[previousIndex];
+    final verticalAngle = line.direction() + (math.pi / 2);
+    final verticalDirection =
+        Offset(math.cos(verticalAngle), math.sin(verticalAngle));
 
-      final maxSectionRadius = math.max(section.radius, previousSection.radius);
+    final startPoint1 = Offset(
+      line.from.dx -
+          (normalized * (width / 2)).dx -
+          (verticalDirection * width).dx,
+      line.from.dy -
+          (normalized * (width / 2)).dy -
+          (verticalDirection * width).dy,
+    );
 
-      final startAngle = tempAngle;
-      final sweepAngle = 360 * (section.value / data.sumValue);
+    final startPoint2 = Offset(
+      line.to.dx +
+          (normalized * (width / 2)).dx -
+          (verticalDirection * width).dx,
+      line.to.dy +
+          (normalized * (width / 2)).dy -
+          (verticalDirection * width).dy,
+    );
 
-      final sectionsStartFrom = center +
-          Offset(
-            math.cos(radians(startAngle)) * (centerRadius - extraLineSize),
-            math.sin(radians(startAngle)) * (centerRadius - extraLineSize),
-          );
+    final startPoint3 = Offset(
+      startPoint2.dx + (verticalDirection * (width * 2)).dx,
+      startPoint2.dy + (verticalDirection * (width * 2)).dy,
+    );
 
-      final sectionsStartTo = center +
-          Offset(
-            math.cos(radians(startAngle)) *
-                (centerRadius + maxSectionRadius + extraLineSize),
-            math.sin(radians(startAngle)) *
-                (centerRadius + maxSectionRadius + extraLineSize),
-          );
+    final startPoint4 = Offset(
+      startPoint1.dx + (verticalDirection * (width * 2)).dx,
+      startPoint1.dy + (verticalDirection * (width * 2)).dy,
+    );
 
-      _sectionsSpaceClearPaint.strokeWidth = data.sectionsSpace;
-      canvasWrapper.drawLine(
-          sectionsStartFrom, sectionsStartTo, _sectionsSpaceClearPaint);
-      tempAngle += sweepAngle;
-    });
-    canvasWrapper.restore();
+    return Path()
+      ..moveTo(startPoint1.dx, startPoint1.dy)
+      ..lineTo(startPoint2.dx, startPoint2.dy)
+      ..lineTo(startPoint3.dx, startPoint3.dy)
+      ..lineTo(startPoint4.dx, startPoint4.dy)
+      ..lineTo(startPoint1.dx, startPoint1.dy);
+  }
+
+  void _drawSection(PieChartSectionData section, Path sectionPath,
+      CanvasWrapper canvasWrapper) {
+    _sectionPaint.color = section.color;
+    _sectionPaint.style = PaintingStyle.fill;
+    canvasWrapper.drawPath(sectionPath, _sectionPaint);
+  }
+
+  void _drawSectionStroke(PieChartSectionData section, Path sectionPath,
+      CanvasWrapper canvasWrapper, Size viewSize) {
+    if (section.borderSide.width != 0.0 &&
+        section.borderSide.color.opacity != 0.0) {
+      canvasWrapper.saveLayer(
+          Rect.fromLTWH(0, 0, viewSize.width, viewSize.height), Paint());
+      canvasWrapper.clipPath(sectionPath);
+
+      _sectionStrokePaint.strokeWidth = section.borderSide.width * 2;
+      _sectionStrokePaint.color = section.borderSide.color;
+      canvasWrapper.drawPath(
+        sectionPath,
+        _sectionStrokePaint,
+      );
+      canvasWrapper.restore();
+    }
   }
 
   /// Calculates layout of overlaying elements, includes:

--- a/test/chart/base/line_test.dart
+++ b/test/chart/base/line_test.dart
@@ -1,0 +1,40 @@
+import 'package:fl_chart/src/utils/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../data_pool.dart';
+
+void main() {
+  const tolerance = 0.001;
+
+  test('test magnitude()', () {
+    expect(line1.magnitude(), closeTo(14.142, tolerance));
+    expect(line2.magnitude(), closeTo(22.360, tolerance));
+    expect(line3.magnitude(), closeTo(18.027, tolerance));
+    expect(line4.magnitude(), closeTo(32.310, tolerance));
+    expect(line5.magnitude(), closeTo(5.830, tolerance));
+  });
+
+  test('test angle()', () {
+    expect(line1.direction(), closeTo(radians(45), tolerance));
+    expect(line2.direction(), closeTo(radians(63.434), tolerance));
+    expect(line3.direction(), closeTo(radians(-3.179), tolerance));
+    expect(line4.direction(), closeTo(radians(68.198), tolerance));
+    expect(line5.direction(), closeTo(radians(59), tolerance));
+  });
+
+  test('test normalize()', () {
+    expect(line1.normalize().dx, closeTo(0.707, tolerance));
+    expect(line1.normalize().dy, closeTo(0.707, tolerance));
+
+    expect(line2.normalize().dx, closeTo(0.447, tolerance));
+    expect(line2.normalize().dy, closeTo(0.894, tolerance));
+
+    expect(line3.normalize().dx, closeTo(-0.998, tolerance));
+    expect(line3.normalize().dy, closeTo(0.0554, tolerance));
+
+    expect(line4.normalize().dx, closeTo(-0.371, tolerance));
+    expect(line4.normalize().dy, closeTo(-0.928, tolerance));
+
+    expect(line5.normalize().dx, closeTo(0.514, tolerance));
+    expect(line5.normalize().dy, closeTo(0.857, tolerance));
+  });
+}

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart/src/chart/base/line.dart';
 import 'package:flutter/material.dart';
 
 final VerticalRangeAnnotation verticalRangeAnnotation1 =
@@ -2987,3 +2988,9 @@ final RadarChartData radarChartData2 = RadarChartData(
   tickBorderData: const BorderSide(color: Colors.pink, width: 2),
   ticksTextStyle: const TextStyle(color: Colors.purple, fontSize: 10),
 );
+
+final Line line1 = Line(const Offset(0, 0), const Offset(10, 10));
+final Line line2 = Line(const Offset(-4, -12), const Offset(6, 8));
+final Line line3 = Line(const Offset(18, -1), const Offset(0, 0));
+final Line line4 = Line(const Offset(8, 8), const Offset(-4, -22));
+final Line line5 = Line(const Offset(2, 3), const Offset(5, 8));


### PR DESCRIPTION
Fixes #818.

Currently, we use this logic to add a separator between PieChart sections:
We draw each section and fill them. Then we remove some lines from the canvas to make the distance between sections. It breaks the stroke. Because we remove a line from the sections.

Now we make a path and draw each section with space by default. And there is no need to remove anything from the canvas. 
Then stroke should work fine now.