### PR TITLE
Fix getNearestTouchedSpot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## newVersion
+* **BUGFIX** Fix getNearestTouchedSpot. Previously it returned the first occurrence of a spot within the threshold, and not the nearest, #641, #645.
+
 ## 0.40.6
 * **IMPROVEMENT** Fix showing zero value in side titles and grid lines when we add negative value. Now we always go through the zero value in each axis, #739.
 * **BUGFIX** Fix example app unsupported operation problem on web, #844.

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1531,17 +1531,29 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     final chartViewSize = getChartUsableDrawSize(viewSize, holder);
 
     /// Find the nearest spot (on X axis)
-    for (var i = 0; i < barData.spots.length; i++) {
-      final spot = barData.spots[i];
-      if (spot.isNotNull()) {
-        if ((touchedPoint.dx - getPixelX(spot.x, chartViewSize, holder))
-                .abs() <=
-            data.lineTouchData.touchSpotThreshold) {
-          return LineBarSpot(barData, barDataPosition, spot);
+    final sortedSpots = <FlSpot>[];
+    double? smallestDistance;
+    for (var spot in barData.spots) {
+      if (spot.isNull()) continue;
+      final distance =
+          (touchedPoint.dx - getPixelX(spot.x, chartViewSize, holder)).abs();
+
+      if (distance <= data.lineTouchData.touchSpotThreshold) {
+        smallestDistance ??= distance;
+
+        if (distance < smallestDistance) {
+          sortedSpots.insert(0, spot);
+          smallestDistance = distance;
+        } else {
+          sortedSpots.add(spot);
         }
       }
     }
 
-    return null;
+    if (sortedSpots.isNotEmpty) {
+      return LineBarSpot(barData, barDataPosition, sortedSpots.first);
+    } else {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Continue of #644 PR Opened by @PerLycke.
desctiption:

> Previously it returned the first occurrence of a spot within the threshold, and not the nearest, which I understand is the purpose of this function.
With the updated function the user is able to set the threshold to a big number (like double.maxFinite) and get the nearest spot from this function. This behaviour (clicking anywhere and get the nearest spot) is seen in e.g. charts_flutter.
AFAIK this shouldn't break anything for existing users, just fix / add the above functionality.
Fixes #641, #645.