### PR TITLE
Make reserved space act like reserved space and not maximum space

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -408,7 +408,10 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
               textDirection: leftTitles.textDirection,
               textScaleFactor: holder.textScale,
             );
-            tp.layout(maxWidth: leftTitles.reservedSize);
+            tp.layout(
+              maxWidth: leftTitles.reservedSize,
+              minWidth: leftTitles.reservedSize,
+            );
             x -= tp.width + leftTitles.margin;
             y -= tp.height / 2;
             x += Utils()
@@ -482,7 +485,10 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
               textDirection: rightTitles.textDirection,
               textScaleFactor: holder.textScale,
             );
-            tp.layout(maxWidth: rightTitles.reservedSize);
+            tp.layout(
+              maxWidth: rightTitles.reservedSize,
+              minWidth: rightTitles.reservedSize,
+            );
             x += rightTitles.margin;
             y -= tp.height / 2;
             x -= Utils()

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -910,7 +910,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
               textDirection: leftTitles.textDirection,
               textScaleFactor: holder.textScale,
             );
-            tp.layout(maxWidth: leftTitles.reservedSize);
+            tp.layout(
+              maxWidth: leftTitles.reservedSize,
+              minWidth: leftTitles.reservedSize,
+            );
             x -= tp.width + leftTitles.margin;
             y -= tp.height / 2;
             x += Utils()
@@ -1001,7 +1004,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
               textDirection: rightTitles.textDirection,
               textScaleFactor: holder.textScale,
             );
-            tp.layout(maxWidth: rightTitles.reservedSize);
+            tp.layout(
+              maxWidth: rightTitles.reservedSize,
+              minWidth: rightTitles.reservedSize,
+            );
 
             x += rightTitles.margin;
             y -= tp.height / 2;

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -76,7 +76,10 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
               textDirection: leftTitles.textDirection,
               textScaleFactor: holder.textScale,
             );
-            tp.layout(maxWidth: leftTitles.reservedSize);
+            tp.layout(
+              maxWidth: leftTitles.reservedSize,
+              minWidth: leftTitles.reservedSize,
+            );
             x -= tp.width + leftTitles.margin;
             y -= tp.height / 2;
 
@@ -168,7 +171,10 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
               textDirection: rightTitles.textDirection,
               textScaleFactor: holder.textScale,
             );
-            tp.layout(maxWidth: rightTitles.reservedSize);
+            tp.layout(
+              maxWidth: rightTitles.reservedSize,
+              minWidth: rightTitles.reservedSize,
+            );
 
             x += rightTitles.margin;
             y -= tp.height / 2;


### PR DESCRIPTION
Hi, it's me again tackling titles issues. The TextAlign PR I made doesn't  work as well as I expected because the texts don't have place to be aligned into. The `SideTitles` class has a field called `reservedSize` but it only sets texts max width. This PR fixes that.
Here are some examples of the issue: 

Aligned to left:
Before:
![Screenshot_1639396244](https://user-images.githubusercontent.com/52886548/145809593-f7e07700-9de4-4f89-a646-9745dadfa5d3.png)
After:
![Screenshot_1639396236](https://user-images.githubusercontent.com/52886548/145809612-a44198de-9b8c-4d67-ac86-c9dde5bbfe83.png)
Aligned to center:
Before:
![Screenshot_1639396253](https://user-images.githubusercontent.com/52886548/145809662-e4439847-175f-4831-a509-44cad15c4f68.png)
After:
![Screenshot_1639396257](https://user-images.githubusercontent.com/52886548/145809679-7b8c09f5-36c3-4312-a8fe-e4871c27ef08.png)

