### PR TITLE
ci: improve codecov configuration

### DIFF
--- a/ .codecov.yml
+++ b/ .codecov.yml
@@ -1,0 +1,7 @@
+comment:
+  require_changes: true
+# Ignore all the file inside the example and
+# end eventually also the autogenerate file
+ignore:
+  - '**/example/'
+  - '**/*.g.dart'


### PR DESCRIPTION
In other to improve the test coverage, we should remove the example directory
because we don't want that also the example enter inside the scoring.

In addition, this improves the GitHub workflows related to the upload of the action, if you like to use this proposal you need to post your codecov secret inside the GitHub action.

Please let me know if you want that I restore the old version of the GitHub workflow

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>