### PR TITLE
Add option to include y distance for nearest touched spot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * **BUGFIX** Allow to show title when axis diff is zero.
 * **IMPROVEMENT** Improve iteration over axis values logic (it solves some minor problems on showing titles when min, max values are below than 1.0).
 * **BREAKING** `LineTouchResponse` response now contains a list of `TouchLineBarSpot` instead of `LineBarSpot`. They are ordered based on their distance to the touch event and also contain that distance.
+* **IMPROVEMENT** Added `distanceCalculator` to `LineTouchData` which is used to calculate the distance between spots and touch events
 
 ## 0.41.0
 * **BUGFIX** Fix getNearestTouchedSpot. Previously it returned the first occurrence of a spot within the threshold, and not the nearest, #641, #645.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **BUGFIX** Fix LineChart width smaller width or height lower than 40, #869, #857.
 * **BUGFIX** Allow to show title when axis diff is zero.
 * **IMPROVEMENT** Improve iteration over axis values logic (it solves some minor problems on showing titles when min, max values are below than 1.0).
+* **BREAKING** `LineTouchResponse` response now contains a list of `TouchLineBarSpot` instead of `LineBarSpot`. They are ordered based on their distance to the touch event and also contain that distance.
 
 ## 0.41.0
 * **BUGFIX** Fix getNearestTouchedSpot. Previously it returned the first occurrence of a spot within the threshold, and not the nearest, #641, #645.

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1444,7 +1444,7 @@ class LineTouchData extends FlTouchData<LineTouchResponse> with EquatableMixin {
         getTouchedSpotIndicator =
             getTouchedSpotIndicator ?? defaultTouchedIndicators,
         touchSpotThreshold = touchSpotThreshold ?? 10,
-        distanceCalculator = distanceCalculator ?? xDistance,
+        distanceCalculator = distanceCalculator ?? _xDistance,
         handleBuiltInTouches = handleBuiltInTouches ?? true,
         getTouchLineStart = getTouchLineStart ?? defaultGetTouchLineStart,
         getTouchLineEnd = getTouchLineEnd ?? defaultGetTouchLineEnd,
@@ -1472,6 +1472,7 @@ class LineTouchData extends FlTouchData<LineTouchResponse> with EquatableMixin {
       getTouchedSpotIndicator:
           getTouchedSpotIndicator ?? this.getTouchedSpotIndicator,
       touchSpotThreshold: touchSpotThreshold ?? this.touchSpotThreshold,
+      distanceCalculator: distanceCalculator ?? this.distanceCalculator,
       getTouchLineStart: getTouchLineStart ?? this.getTouchLineStart,
       getTouchLineEnd: getTouchLineEnd ?? this.getTouchLineEnd,
       handleBuiltInTouches: handleBuiltInTouches ?? this.handleBuiltInTouches,
@@ -1512,7 +1513,7 @@ typedef CalculateTouchDistance = double Function(
     Offset touchPoint, Offset spotPixelCoordinates);
 
 /// Default distanceCalculator only considers distance on x axis
-double xDistance(Offset touchPoint, Offset spotPixelCoordinates) {
+double _xDistance(Offset touchPoint, Offset spotPixelCoordinates) {
   return ((touchPoint.dx - spotPixelCoordinates.dx)).abs();
 }
 

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -169,6 +169,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |touchTooltipData|a [LineTouchTooltipData](#LineTouchTooltipData), that determines how show the tooltip on top of touched spots (appearance of the showing tooltip bubble)|LineTouchTooltipData|
 |getTouchedSpotIndicator| a callback that retrieves list of [TouchedSpotIndicatorData](#TouchedSpotIndicatorData) by the given list of [LineBarSpot](#LineBarSpot) for showing the indicators on touched spots|defaultTouchedIndicators|
 |touchSpotThreshold|the threshold of the touch accuracy|10|
+|distanceCalculator| a function to calculate the distance between a spot and a touch event| _xDistance|
 |handleBuiltInTouches| set this true if you want the built in touch handling (show a tooltip bubble and an indicator on touched spots) | true|
 |getTouchLineStart| controls where the line starts, default is bottom of the chart| defaultGetTouchLineStart|
 |getTouchLineEnd| controls where the line ends, default is the touch point| defaultGetTouchLineEnd|
@@ -212,10 +213,19 @@ When you change the chart's state, it animates to the new state internally (usin
 |spotIndex|index of the target [FlSpot](#FlSpot) inside [LineChartBarData](#LineChartBarData)|null|
 
 
+### TouchLineBarSpot
+|PropName|Description|default value|
+|:-------|:----------|:------------|
+|bar|the [LineChartBarData](#LineChartBarData) that contains a spot|null|
+|barIndex|index of the target [LineChartBarData](#LineChartBarData) inside [LineChartData](#LineChartData)|null|
+|spotIndex|index of the target [FlSpot](#FlSpot) inside [LineChartBarData](#LineChartBarData)|null|
+|distance|distance to the touch event|null|
+
+
 ### LineTouchResponse
 |PropName|Description|default value|
 |:-------|:----------|:------------|
-|lineBarSpots|a list of [LineBarSpot](#LineBarSpot)|null|
+|lineBarSpots|a list of [TouchLineBarSpot](#TouchLineBarSpot)|null|
 
 ### ShowingTooltipIndicators
 |PropName|Description|default value|

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -274,15 +274,17 @@ class MockData {
     33,
   );
 
-  static final lineBarSpot1 = LineBarSpot(
+  static final lineBarSpot1 = TouchLineBarSpot(
     lineChartBarData1,
     0,
     lineChartBarData1.spots.first,
+    0,
   );
-  static final lineBarSpot2 = LineBarSpot(
+  static final lineBarSpot2 = TouchLineBarSpot(
     MockData.lineChartBarData1,
     1,
     MockData.lineChartBarData1.spots.last,
+    2,
   );
 
   static final lineTouchResponse1 =
@@ -1082,27 +1084,27 @@ final LineChartBarData lineChartBarData9 = LineChartBarData(
   showingIndicators: [0, 1],
 );
 
-final LineBarSpot lineBarSpot1 = LineBarSpot(
+final TouchLineBarSpot lineBarSpot1 = TouchLineBarSpot(
   lineChartBarData1,
   0,
   flSpot1,
+  0,
 );
-final LineBarSpot lineBarSpot1Clone = LineBarSpot(
+final TouchLineBarSpot lineBarSpot1Clone = TouchLineBarSpot(
   lineChartBarData1Clone,
   0,
   flSpot1Clone,
+  0,
 );
 
-final LineBarSpot lineBarSpot2 = LineBarSpot(
-  lineChartBarData1,
-  2,
-  flSpot1,
-);
+final TouchLineBarSpot lineBarSpot2 =
+    TouchLineBarSpot(lineChartBarData1, 2, flSpot1, 2);
 
-final LineBarSpot lineBarSpot3 = LineBarSpot(
+final TouchLineBarSpot lineBarSpot3 = TouchLineBarSpot(
   lineChartBarData1,
   100,
   flSpot1,
+  2,
 );
 
 final LineTouchResponse lineTouchResponse1 = LineTouchResponse(

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -2673,6 +2673,74 @@ void main() {
               .length,
           2);
     });
+
+    test('test 3', () {
+      const viewSize = Size(100, 100);
+
+      final LineChartBarData lineChartBarData1 = LineChartBarData(
+        show: true,
+        spots: const [
+          FlSpot(1, 1),
+          FlSpot(2, 1),
+          FlSpot(3, 1),
+          FlSpot(8, 1),
+        ],
+        dotData: FlDotData(show: true),
+        barWidth: 80,
+        isStrokeCapRound: true,
+        isStepLineChart: true,
+        shadow: const Shadow(
+          color: Color(0x0100FF00),
+          offset: Offset(10, 15),
+          blurRadius: 10,
+        ),
+      );
+
+      final LineChartBarData lineChartBarData2 = LineChartBarData(
+        show: true,
+        spots: const [
+          FlSpot(1.3, 1),
+          FlSpot(2, 1),
+          FlSpot(3, 1),
+          FlSpot(4, 1),
+        ],
+        dotData: FlDotData(show: true),
+        barWidth: 80,
+        isStrokeCapRound: true,
+        isStepLineChart: true,
+        shadow: const Shadow(
+          color: Color(0x0100FF00),
+          offset: Offset(10, 15),
+          blurRadius: 10,
+        ),
+      );
+
+      final LineChartData data = LineChartData(
+          minY: 0,
+          maxY: 10,
+          minX: 0,
+          maxX: 10,
+          lineBarsData: [lineChartBarData1, lineChartBarData2],
+          showingTooltipIndicators: [],
+          titlesData: FlTitlesData(show: false),
+          axisTitleData: FlAxisTitleData(show: false),
+          lineTouchData: LineTouchData(
+            touchSpotThreshold: 5,
+          ));
+
+      final LineChartPainter lineChartPainter = LineChartPainter();
+      final holder = PaintHolder<LineChartData>(data, data, 1.0);
+
+      final result1 =
+          lineChartPainter.handleTouch(const Offset(11, 0), viewSize, holder)!;
+      expect(result1[0].barIndex, 0);
+      expect(result1[1].barIndex, 1);
+
+      final result2 =
+          lineChartPainter.handleTouch(const Offset(12, 0), viewSize, holder)!;
+      expect(result2[0].barIndex, 1);
+      expect(result2[1].barIndex, 0);
+    });
   });
 
   group('getNearestTouchedSpot()', () {
@@ -2824,6 +2892,91 @@ void main() {
           viewSize, const Offset(10.0, 0), data.lineBarsData[1], 1, holder);
       expect(result3!.barIndex, 1);
       expect(result3.spotIndex, 0);
+    });
+
+    test('test 3', () {
+      const viewSize = Size(100, 100);
+
+      final LineChartBarData lineChartBarData1 = LineChartBarData(
+        show: true,
+        spots: const [
+          FlSpot(1, 1),
+          FlSpot(4, 1),
+          FlSpot(6, 4),
+          FlSpot(8, 1),
+        ],
+        dotData: FlDotData(show: true),
+        barWidth: 80,
+        isStrokeCapRound: true,
+        isStepLineChart: true,
+        shadow: const Shadow(
+          color: Color(0x0100FF00),
+          offset: Offset(10, 15),
+          blurRadius: 10,
+        ),
+      );
+
+      final LineChartBarData lineChartBarData2 = LineChartBarData(
+        show: true,
+        spots: const [
+          FlSpot(1.1, 4),
+          FlSpot(2, 4),
+          FlSpot(3.5, 1),
+          FlSpot(4.3, 4),
+        ],
+        dotData: FlDotData(show: true),
+        barWidth: 80,
+        isStrokeCapRound: true,
+        isStepLineChart: true,
+        shadow: const Shadow(
+          color: Color(0x0100FF00),
+          offset: Offset(10, 15),
+          blurRadius: 10,
+        ),
+      );
+
+      final LineChartData data = LineChartData(
+          minY: 0,
+          maxY: 10,
+          minX: 0,
+          maxX: 10,
+          lineBarsData: [lineChartBarData1, lineChartBarData2],
+          showingTooltipIndicators: [],
+          titlesData: FlTitlesData(show: false),
+          axisTitleData: FlAxisTitleData(show: false),
+          lineTouchData: LineTouchData(
+            distanceCalculator: (Offset a, Offset b) {
+              final dx = a.dx - b.dx;
+              final dy = a.dy - b.dy;
+              return math.sqrt(dx * dx + dy * dy);
+            },
+            touchSpotThreshold: 5,
+          ));
+
+      final LineChartPainter lineChartPainter = LineChartPainter();
+      final holder = PaintHolder<LineChartData>(data, data, 1.0);
+      expect(
+          lineChartPainter.getNearestTouchedSpot(
+              viewSize, const Offset(30, 0), data.lineBarsData[0], 0, holder),
+          null);
+      final result1 = lineChartPainter.getNearestTouchedSpot(
+          viewSize, const Offset(60, 65), data.lineBarsData[0], 0, holder);
+      expect(result1!.barIndex, 0);
+      expect(result1.spotIndex, 2);
+
+      expect(
+          lineChartPainter.getNearestTouchedSpot(viewSize,
+              const Offset(60, 65.01), data.lineBarsData[0], 0, holder),
+          null);
+      expect(
+          lineChartPainter.getNearestTouchedSpot(viewSize,
+              const Offset(29.99, 0), data.lineBarsData[1], 1, holder),
+          null);
+
+      final result2 = lineChartPainter.getNearestTouchedSpot(
+          viewSize, const Offset(63.5, 63.5), data.lineBarsData[0], 0, holder);
+      expect(result2!.barIndex, 0);
+      expect(result2.spotIndex, 2);
     });
   });
 

--- a/test/chart/line_chart/line_chart_painter_test.mocks.dart
+++ b/test/chart/line_chart/line_chart_painter_test.mocks.dart
@@ -734,13 +734,13 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
       (super.noSuchMethod(Invocation.method(#getTopOffsetDrawSize, [holder]),
           returnValue: 0.0) as double);
   @override
-  List<_i7.LineBarSpot>? handleTouch(_i2.Offset? localPosition, _i2.Size? size,
-          _i10.PaintHolder<_i7.LineChartData>? holder) =>
+  List<_i7.TouchLineBarSpot>? handleTouch(_i2.Offset? localPosition,
+          _i2.Size? size, _i10.PaintHolder<_i7.LineChartData>? holder) =>
       (super.noSuchMethod(
               Invocation.method(#handleTouch, [localPosition, size, holder]))
-          as List<_i7.LineBarSpot>?);
+          as List<_i7.TouchLineBarSpot>?);
   @override
-  _i7.LineBarSpot? getNearestTouchedSpot(
+  _i7.TouchLineBarSpot? getNearestTouchedSpot(
           _i2.Size? viewSize,
           _i2.Offset? touchedPoint,
           _i7.LineChartBarData? barData,
@@ -752,7 +752,7 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
         barData,
         barDataPosition,
         holder
-      ])) as _i7.LineBarSpot?);
+      ])) as _i7.TouchLineBarSpot?);
   @override
   void drawAxisTitles(
           _i3.BuildContext? context,

--- a/test/chart/line_chart/line_chart_renderer_test.mocks.dart
+++ b/test/chart/line_chart/line_chart_renderer_test.mocks.dart
@@ -706,13 +706,13 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
       (super.noSuchMethod(Invocation.method(#getTopOffsetDrawSize, [holder]),
           returnValue: 0.0) as double);
   @override
-  List<_i12.LineBarSpot>? handleTouch(_i2.Offset? localPosition, _i2.Size? size,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+  List<_i12.TouchLineBarSpot>? handleTouch(_i2.Offset? localPosition,
+          _i2.Size? size, _i11.PaintHolder<_i12.LineChartData>? holder) =>
       (super.noSuchMethod(
               Invocation.method(#handleTouch, [localPosition, size, holder]))
-          as List<_i12.LineBarSpot>?);
+          as List<_i12.TouchLineBarSpot>?);
   @override
-  _i12.LineBarSpot? getNearestTouchedSpot(
+  _i12.TouchLineBarSpot? getNearestTouchedSpot(
           _i2.Size? viewSize,
           _i2.Offset? touchedPoint,
           _i12.LineChartBarData? barData,
@@ -724,7 +724,7 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
         barData,
         barDataPosition,
         holder
-      ])) as _i12.LineBarSpot?);
+      ])) as _i12.TouchLineBarSpot?);
   @override
   void drawAxisTitles(
           _i6.BuildContext? context,


### PR DESCRIPTION
Instead of only considering the distance on the x axis when checking for the closest spot, this feature allows to choose the closest spot based on Euclidean distance

TODO: 
- [x] Write tests


Fixes #716, #261

