### PR TITLE
Implement `clipData` feature in scatter chart.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## newVersion
+* **BUGFIX** Fix `clipData` implementation in ScatterChart, #897.
 * **BUGFIX** Fix PieChart changing sections issue (we have disabled semantics for pieChart badgeWidgets), #861.
 * **BUGFIX** Fix LineChart width smaller width or height lower than 40, #869, #857.
 * **BUGFIX** Allow to show title when axis diff is zero.

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -3,9 +3,9 @@ import 'dart:ui';
 
 import 'package:equatable/equatable.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart/src/extensions/color_extension.dart';
 import 'package:fl_chart/src/utils/lerp.dart';
 import 'package:flutter/material.dart';
-import 'package:fl_chart/src/extensions/color_extension.dart';
 
 import 'scatter_chart_helper.dart';
 
@@ -18,6 +18,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
   final FlTitlesData titlesData;
   final ScatterTouchData scatterTouchData;
   final List<int> showingTooltipIndicators;
+  final bool clipBubble;
 
   /// [ScatterChart] draws some points in a square space,
   /// points are defined by [scatterSpots],
@@ -39,6 +40,9 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
   /// just put spot indices you want to show it on top of them.
   ///
   /// [clipData] forces the [LineChart] to draw lines inside the chart bounding box.
+  ///
+  /// [clipBubble] forces the [ScatterChart] to crop the bubbles and make sure it does
+  /// not cross the chart bounding box.
   ScatterChartData({
     List<ScatterSpot>? scatterSpots,
     FlTitlesData? titlesData,
@@ -53,10 +57,12 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
     double? maxY,
     FlClipData? clipData,
     Color? backgroundColor,
+    bool? clipBubble,
   })  : scatterSpots = scatterSpots ?? const [],
         titlesData = titlesData ?? FlTitlesData(),
         scatterTouchData = scatterTouchData ?? ScatterTouchData(),
         showingTooltipIndicators = showingTooltipIndicators ?? const [],
+        clipBubble = clipBubble ?? false,
         super(
           gridData: gridData ?? FlGridData(),
           touchData: scatterTouchData ?? ScatterTouchData(),
@@ -101,6 +107,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
         minY: lerpDouble(a.minY, b.minY, t),
         maxY: lerpDouble(a.maxY, b.maxY, t),
         clipData: b.clipData,
+        clipBubble: b.clipBubble,
         backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
       );
     } else {
@@ -124,6 +131,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
     double? maxY,
     FlClipData? clipData,
     Color? backgroundColor,
+    bool? clipBubble,
   }) {
     return ScatterChartData(
       scatterSpots: scatterSpots ?? this.scatterSpots,
@@ -140,6 +148,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
       maxY: maxY ?? this.maxY,
       clipData: clipData ?? this.clipData,
       backgroundColor: backgroundColor ?? this.backgroundColor,
+      clipBubble: clipBubble ?? this.clipBubble,
     );
   }
 
@@ -161,6 +170,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
         minY,
         maxY,
         rangeAnnotations,
+        clipBubble,
       ];
 }
 

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -18,7 +18,6 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
   final FlTitlesData titlesData;
   final ScatterTouchData scatterTouchData;
   final List<int> showingTooltipIndicators;
-  final bool clipBubble;
 
   /// [ScatterChart] draws some points in a square space,
   /// points are defined by [scatterSpots],
@@ -40,9 +39,6 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
   /// just put spot indices you want to show it on top of them.
   ///
   /// [clipData] forces the [LineChart] to draw lines inside the chart bounding box.
-  ///
-  /// [clipBubble] forces the [ScatterChart] to crop the bubbles and make sure it does
-  /// not cross the chart bounding box.
   ScatterChartData({
     List<ScatterSpot>? scatterSpots,
     FlTitlesData? titlesData,
@@ -57,12 +53,10 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
     double? maxY,
     FlClipData? clipData,
     Color? backgroundColor,
-    bool? clipBubble,
   })  : scatterSpots = scatterSpots ?? const [],
         titlesData = titlesData ?? FlTitlesData(),
         scatterTouchData = scatterTouchData ?? ScatterTouchData(),
         showingTooltipIndicators = showingTooltipIndicators ?? const [],
-        clipBubble = clipBubble ?? false,
         super(
           gridData: gridData ?? FlGridData(),
           touchData: scatterTouchData ?? ScatterTouchData(),
@@ -107,7 +101,6 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
         minY: lerpDouble(a.minY, b.minY, t),
         maxY: lerpDouble(a.maxY, b.maxY, t),
         clipData: b.clipData,
-        clipBubble: b.clipBubble,
         backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
       );
     } else {
@@ -131,7 +124,6 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
     double? maxY,
     FlClipData? clipData,
     Color? backgroundColor,
-    bool? clipBubble,
   }) {
     return ScatterChartData(
       scatterSpots: scatterSpots ?? this.scatterSpots,
@@ -148,7 +140,6 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
       maxY: maxY ?? this.maxY,
       clipData: clipData ?? this.clipData,
       backgroundColor: backgroundColor ?? this.backgroundColor,
-      clipBubble: clipBubble ?? this.clipBubble,
     );
   }
 
@@ -170,7 +161,6 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
         minY,
         maxY,
         rangeAnnotations,
-        clipBubble,
       ];
 }
 

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -227,18 +227,47 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
     final data = holder.data;
     final viewSize = canvasWrapper.size;
     final chartUsableSize = getChartUsableDrawSize(viewSize, holder);
+    final clip = data.clipData;
+    final border = data.borderData.show ? data.borderData.border : null;
 
-    final leftStartingPoint = getLeftOffsetDrawSize(holder);
-    final topStartingPoint = getTopOffsetDrawSize(holder);
+    if (data.clipData.any) {
+      canvasWrapper.saveLayer(
+        Rect.fromLTRB(
+          0,
+          0,
+          canvasWrapper.size.width,
+          canvasWrapper.size.height,
+        ),
+        Paint(),
+      );
 
-    if (holder.data.clipBubble) {
-      // clip the canvas, so that bubble does not cross the axis.
-      canvasWrapper.clipRect(Rect.fromLTWH(
-        leftStartingPoint,
-        topStartingPoint,
-        chartUsableSize.width,
-        chartUsableSize.height,
-      ));
+      var left = 0.0;
+      var top = 0.0;
+      var right = viewSize.width;
+      var bottom = viewSize.height;
+
+      if (clip.left) {
+        final borderWidth = border?.left.width ?? 0;
+        left = getLeftOffsetDrawSize(holder) - (borderWidth / 2);
+      }
+      if (clip.top) {
+        final borderWidth = border?.top.width ?? 0;
+        top = getTopOffsetDrawSize(holder) - (borderWidth / 2);
+      }
+      if (clip.right) {
+        final borderWidth = border?.right.width ?? 0;
+        right = getLeftOffsetDrawSize(holder) +
+            chartUsableSize.width +
+            (borderWidth / 2);
+      }
+      if (clip.bottom) {
+        final borderWidth = border?.bottom.width ?? 0;
+        bottom = getTopOffsetDrawSize(holder) +
+            chartUsableSize.height +
+            (borderWidth / 2);
+      }
+
+      canvasWrapper.clipRect(Rect.fromLTRB(left, top, right, bottom));
     }
 
     for (final scatterSpot in data.scatterSpots) {
@@ -257,8 +286,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       );
     }
 
-    if (holder.data.clipBubble) {
-      // restore the clip to get back original region.
+    if (data.clipData.any) {
       canvasWrapper.restore();
     }
   }

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -248,22 +248,22 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
 
       if (clip.left) {
         final borderWidth = border?.left.width ?? 0;
-        left = getLeftOffsetDrawSize(holder) - (borderWidth / 2);
+        left = getLeftOffsetDrawSize(holder) + (borderWidth / 2);
       }
       if (clip.top) {
         final borderWidth = border?.top.width ?? 0;
-        top = getTopOffsetDrawSize(holder) - (borderWidth / 2);
+        top = getTopOffsetDrawSize(holder) + (borderWidth / 2);
       }
       if (clip.right) {
         final borderWidth = border?.right.width ?? 0;
         right = getLeftOffsetDrawSize(holder) +
-            chartUsableSize.width +
+            chartUsableSize.width -
             (borderWidth / 2);
       }
       if (clip.bottom) {
         final borderWidth = border?.bottom.width ?? 0;
         bottom = getTopOffsetDrawSize(holder) +
-            chartUsableSize.height +
+            chartUsableSize.height -
             (borderWidth / 2);
       }
 

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -227,6 +227,20 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
     final data = holder.data;
     final viewSize = canvasWrapper.size;
     final chartUsableSize = getChartUsableDrawSize(viewSize, holder);
+
+    final leftStartingPoint = getLeftOffsetDrawSize(holder);
+    final topStartingPoint = getTopOffsetDrawSize(holder);
+
+    if (holder.data.clipBubble) {
+      // clip the canvas, so that bubble does not cross the axis.
+      canvasWrapper.clipRect(Rect.fromLTWH(
+        leftStartingPoint,
+        topStartingPoint,
+        chartUsableSize.width,
+        chartUsableSize.height,
+      ));
+    }
+
     for (final scatterSpot in data.scatterSpots) {
       if (!scatterSpot.show) {
         continue;
@@ -241,6 +255,11 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
         scatterSpot.radius,
         _spotsPaint,
       );
+    }
+
+    if (holder.data.clipBubble) {
+      // restore the clip to get back original region.
+      canvasWrapper.restore();
     }
   }
 

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2434,6 +2434,7 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
     topTitles: SideTitles(showTitles: false),
     bottomTitles: SideTitles(showTitles: false),
   ),
+  clipBubble: true,
 );
 final ScatterChartData scatterChartData1Clone = ScatterChartData(
   minY: 0,
@@ -2521,6 +2522,7 @@ final ScatterChartData scatterChartData1Clone = ScatterChartData(
     topTitles: SideTitles(showTitles: false),
     bottomTitles: SideTitles(showTitles: false),
   ),
+  clipBubble: true,
 );
 
 final BarChartRodStackItem barChartRodStackItem1 = BarChartRodStackItem(

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2434,7 +2434,6 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
     topTitles: SideTitles(showTitles: false),
     bottomTitles: SideTitles(showTitles: false),
   ),
-  clipBubble: true,
 );
 final ScatterChartData scatterChartData1Clone = ScatterChartData(
   minY: 0,
@@ -2522,7 +2521,6 @@ final ScatterChartData scatterChartData1Clone = ScatterChartData(
     topTitles: SideTitles(showTitles: false),
     bottomTitles: SideTitles(showTitles: false),
   ),
-  clipBubble: true,
 );
 
 final BarChartRodStackItem barChartRodStackItem1 = BarChartRodStackItem(

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -424,6 +424,7 @@ void main() {
           ScatterSpot(7, 5, radius: 6),
         ],
         titlesData: FlTitlesData(show: false),
+        clipData: FlClipData.all(),
       );
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
@@ -442,6 +443,8 @@ void main() {
           .called(1);
       verify(_mockCanvasWrapper.drawCircle(const Offset(70, 50), 6, any))
           .called(1);
+
+      verify(_mockCanvasWrapper.clipRect(any)).called(1);
     });
 
     test('test 2', () {
@@ -459,7 +462,7 @@ void main() {
           ScatterSpot(7, 5, show: false),
         ],
         titlesData: FlTitlesData(show: false),
-        clipBubble: false,
+        clipData: FlClipData.none(),
       );
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
@@ -472,47 +475,8 @@ void main() {
         holder,
       );
 
-      verifyNever(_mockCanvasWrapper.clipRect(any));
       verifyNever(_mockCanvasWrapper.drawCircle(any, any, any));
-      verifyNever(_mockCanvasWrapper.restore());
-    });
-
-    test('test 3', () {
-      const viewSize = Size(100, 100);
-
-      final ScatterChartData data = ScatterChartData(
-        minY: 0,
-        maxY: 10,
-        minX: 0,
-        maxX: 10,
-        scatterSpots: [
-          ScatterSpot(1, 1, show: false),
-          ScatterSpot(3, 9, show: false),
-          ScatterSpot(8, 2, show: false),
-          ScatterSpot(7, 5, show: false),
-        ],
-        titlesData: FlTitlesData(show: false),
-        clipBubble: true,
-      );
-
-      final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
-      final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenReturn(viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
-      scatterChartPainter.drawSpots(
-        _mockCanvasWrapper,
-        holder,
-      );
-
-      verify(_mockCanvasWrapper.clipRect(
-        Rect.fromPoints(
-          const Offset(0, 0),
-          const Offset(100, 100),
-        ),
-      )).called(1);
-
-      verify(_mockCanvasWrapper.restore()).called(1);
+      verifyNever(_mockCanvasWrapper.clipRect(any));
     });
   });
 

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -1,14 +1,15 @@
 import 'dart:math' as math;
 
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
 import 'package:fl_chart/src/chart/scatter_chart/scatter_chart_painter.dart';
 import 'package:fl_chart/src/utils/canvas_wrapper.dart';
 import 'package:fl_chart/src/utils/utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+
 import '../data_pool.dart';
 import 'scatter_chart_painter_test.mocks.dart';
 
@@ -458,6 +459,7 @@ void main() {
           ScatterSpot(7, 5, show: false),
         ],
         titlesData: FlTitlesData(show: false),
+        clipBubble: false,
       );
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
@@ -470,7 +472,47 @@ void main() {
         holder,
       );
 
+      verifyNever(_mockCanvasWrapper.clipRect(any));
       verifyNever(_mockCanvasWrapper.drawCircle(any, any, any));
+      verifyNever(_mockCanvasWrapper.restore());
+    });
+
+    test('test 3', () {
+      const viewSize = Size(100, 100);
+
+      final ScatterChartData data = ScatterChartData(
+        minY: 0,
+        maxY: 10,
+        minX: 0,
+        maxX: 10,
+        scatterSpots: [
+          ScatterSpot(1, 1, show: false),
+          ScatterSpot(3, 9, show: false),
+          ScatterSpot(8, 2, show: false),
+          ScatterSpot(7, 5, show: false),
+        ],
+        titlesData: FlTitlesData(show: false),
+        clipBubble: true,
+      );
+
+      final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
+      final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
+      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
+      when(_mockCanvasWrapper.size).thenReturn(viewSize);
+      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      scatterChartPainter.drawSpots(
+        _mockCanvasWrapper,
+        holder,
+      );
+
+      verify(_mockCanvasWrapper.clipRect(
+        Rect.fromPoints(
+          const Offset(0, 0),
+          const Offset(100, 100),
+        ),
+      )).called(1);
+
+      verify(_mockCanvasWrapper.restore()).called(1);
     });
   });
 


### PR DESCRIPTION
#897.

The Scatter chart can be used as a Bubble chart by providing different radii. So, when the radius is bigger and close to the axis of the chart, it is used to cross the axis and go out of the chart.

So, in my approach, I've added a new attribute in `ScatterChartData` called `clipBubble`. If we set it to true, it will clip the chart before drawing the spots such that the bubbles never cross the chart's axes. After the bubbles are drawn, it again restores the original region.