### PR TITLE
Label feature in Scatter Chart

### DIFF
--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -187,19 +187,19 @@ class ScatterSpot extends FlSpot with EquatableMixin {
   /// Determines color of the spot.
   Color color;
 
+  /// Determines label of the spot.
+  final String? label;
+
   /// You can change [show] value to show or hide the spot,
   /// [x], and [y] defines the location of spot in the [ScatterChart],
   /// [radius] defines the size of spot, and [color] defines the color of it.
-  ScatterSpot(
-    double x,
-    double y, {
-    bool? show,
-    double? radius,
-    Color? color,
-  })  : show = show ?? true,
+  ScatterSpot(double x, double y,
+      {bool? show, double? radius, Color? color, String? label})
+      : show = show ?? true,
         radius = radius ?? 6,
         color = color ??
             Colors.primaries[((x * y) % Colors.primaries.length).toInt()],
+        label = label,
         super(x, y);
 
   @override
@@ -209,6 +209,7 @@ class ScatterSpot extends FlSpot with EquatableMixin {
     bool? show,
     double? radius,
     Color? color,
+    String? label,
   }) {
     return ScatterSpot(
       x ?? this.x,
@@ -216,6 +217,7 @@ class ScatterSpot extends FlSpot with EquatableMixin {
       show: show ?? this.show,
       radius: radius ?? this.radius,
       color: color ?? this.color,
+      label: label,
     );
   }
 
@@ -227,6 +229,7 @@ class ScatterSpot extends FlSpot with EquatableMixin {
       show: b.show,
       radius: lerpDouble(a.radius, b.radius, t),
       color: Color.lerp(a.color, b.color, t),
+      label: b.label,
     );
   }
 
@@ -238,6 +241,7 @@ class ScatterSpot extends FlSpot with EquatableMixin {
         show,
         radius,
         color,
+        label,
       ];
 }
 

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -18,6 +18,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
   final FlTitlesData titlesData;
   final ScatterTouchData scatterTouchData;
   final List<int> showingTooltipIndicators;
+  final ScatterLabelSettings scatterLabelSettings;
 
   /// [ScatterChart] draws some points in a square space,
   /// points are defined by [scatterSpots],
@@ -55,10 +56,12 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
     double? baselineY,
     FlClipData? clipData,
     Color? backgroundColor,
+    ScatterLabelSettings? scatterLabelSettings,
   })  : scatterSpots = scatterSpots ?? const [],
         titlesData = titlesData ?? FlTitlesData(),
         scatterTouchData = scatterTouchData ?? ScatterTouchData(),
         showingTooltipIndicators = showingTooltipIndicators ?? const [],
+        scatterLabelSettings = scatterLabelSettings ?? ScatterLabelSettings(),
         super(
           gridData: gridData ?? FlGridData(),
           touchData: scatterTouchData ?? ScatterTouchData(),
@@ -108,6 +111,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
         baselineY: lerpDouble(a.baselineY, b.baselineY, t),
         clipData: b.clipData,
         backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
+        scatterLabelSettings: b.scatterLabelSettings,
       );
     } else {
       throw Exception('Illegal State');
@@ -132,6 +136,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
     double? baselineY,
     FlClipData? clipData,
     Color? backgroundColor,
+    ScatterLabelSettings? scatterLabelSettings,
   }) {
     return ScatterChartData(
       scatterSpots: scatterSpots ?? this.scatterSpots,
@@ -150,6 +155,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
       baselineY: baselineY ?? this.baselineY,
       clipData: clipData ?? this.clipData,
       backgroundColor: backgroundColor ?? this.backgroundColor,
+      scatterLabelSettings: scatterLabelSettings ?? this.scatterLabelSettings,
     );
   }
 
@@ -173,6 +179,7 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
         maxY,
         baselineY,
         rangeAnnotations,
+        scatterLabelSettings,
       ];
 }
 
@@ -574,4 +581,50 @@ class ScatterChartDataTween extends Tween<ScatterChartData> {
   ScatterChartData lerp(double t) {
     return begin!.lerp(begin!, end!, t);
   }
+}
+
+/// Defines information about the labels in the [ScatterChart]
+class ScatterLabelSettings with EquatableMixin {
+  /// Determines whether to show or hide the labels
+  final bool showLabel;
+
+  /// Determines style of the labels
+  final TextStyle? textStyle;
+
+  /// You can change [showLabel] value to show or hide the label,
+  /// [textStyle] defines the style of label in the [ScatterChart].
+  ScatterLabelSettings({
+    bool? showLabel,
+    TextStyle? textStyle,
+  })  : showLabel = showLabel ?? false,
+        textStyle = textStyle;
+
+  ScatterLabelSettings copyWith({
+    bool? showLabel,
+    TextStyle? textStyle,
+  }) {
+    return ScatterLabelSettings(
+      showLabel: showLabel ?? this.showLabel,
+      textStyle: textStyle,
+    );
+  }
+
+  /// Lerps a [ScatterLabelSettings] based on [t] value, check [Tween.lerp].
+  static ScatterLabelSettings lerp(
+    ScatterLabelSettings a,
+    ScatterLabelSettings b,
+    double t,
+  ) {
+    return ScatterLabelSettings(
+      showLabel: b.showLabel,
+      textStyle: b.textStyle,
+    );
+  }
+
+  /// Used for equality check, see [EquatableMixin].
+  @override
+  List<Object?> get props => [
+        showLabel,
+        textStyle,
+      ];
 }

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -195,7 +195,7 @@ class ScatterSpot extends FlSpot with EquatableMixin {
   Color color;
 
   /// Determines label of the spot.
-  final String? label;
+  final String label;
 
   /// You can change [show] value to show or hide the spot,
   /// [x], and [y] defines the location of spot in the [ScatterChart],
@@ -206,7 +206,7 @@ class ScatterSpot extends FlSpot with EquatableMixin {
         radius = radius ?? 6,
         color = color ??
             Colors.primaries[((x * y) % Colors.primaries.length).toInt()],
-        label = label,
+        label = label ?? '',
         super(x, y);
 
   @override
@@ -224,7 +224,7 @@ class ScatterSpot extends FlSpot with EquatableMixin {
       show: show ?? this.show,
       radius: radius ?? this.radius,
       color: color ?? this.color,
-      label: label,
+      label: label ?? this.label,
     );
   }
 

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -111,7 +111,8 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
         baselineY: lerpDouble(a.baselineY, b.baselineY, t),
         clipData: b.clipData,
         backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
-        scatterLabelSettings: b.scatterLabelSettings,
+        scatterLabelSettings: ScatterLabelSettings.lerp(
+            a.scatterLabelSettings, b.scatterLabelSettings, t),
       );
     } else {
       throw Exception('Illegal State');
@@ -579,32 +580,47 @@ class ScatterChartDataTween extends Tween<ScatterChartData> {
   }
 }
 
-/// It gives you the index value of the spot and gets the text style of the label.
-typedef GetLabelTextStyleFunction = TextStyle Function(int spotIndex);
+/// It gives you the index value as well as the spot and gets the text style of the label.
+typedef GetLabelTextStyleFunction = TextStyle? Function(
+  int spotIndex,
+  ScatterSpot spot,
+);
 
-/// It gives you the index value of the spot and returns the label of the spot.
-typedef GetLabelFunction = String Function(int spotIndex);
+/// It gives you the index value as well as the spot and returns the label of the spot.
+typedef GetLabelFunction = String Function(
+  int spotIndex,
+  ScatterSpot spot,
+);
 
 /// It gives you the default text style of the label for a spot.
-TextStyle getDefaultLabelTextStyleFunction(int spotIndex) {
-  return const TextStyle();
+TextStyle? getDefaultLabelTextStyleFunction(
+  int spotIndex,
+  ScatterSpot spot,
+) {
+  return null;
 }
 
 /// It gives you the default label of the spot.
-String getDefaultLabelFunction(int spotIndex) {
-  return '';
+String getDefaultLabelFunction(
+  int spotIndex,
+  ScatterSpot spot,
+) {
+  return '${spot.radius}';
 }
 
 /// Defines information about the labels in the [ScatterChart]
 class ScatterLabelSettings with EquatableMixin {
-  /// Determines whether to show or hide the labels
+  /// Determines whether to show or hide the labels.
   final bool showLabel;
 
-  /// This function gives you the index value of the spot in the list and returns the text style
+  /// This function gives you the index value of the spot in the list and returns the text style.
   final GetLabelTextStyleFunction getLabelTextStyleFunction;
 
   /// This function gives you the index value of the spot in the list and returns the label.
   final GetLabelFunction getLabelFunction;
+
+  /// Determines the direction of the text for the labels.
+  final TextDirection textDirection;
 
   /// You can change [showLabel] value to show or hide the label,
   /// [textStyle] defines the style of label in the [ScatterChart].
@@ -612,21 +628,25 @@ class ScatterLabelSettings with EquatableMixin {
     bool? showLabel,
     GetLabelTextStyleFunction? getLabelTextStyleFunction,
     GetLabelFunction? getLabelFunction,
+    TextDirection? textDirection,
   })  : showLabel = showLabel ?? false,
         getLabelTextStyleFunction =
             getLabelTextStyleFunction ?? getDefaultLabelTextStyleFunction,
-        getLabelFunction = getLabelFunction ?? getDefaultLabelFunction;
+        getLabelFunction = getLabelFunction ?? getDefaultLabelFunction,
+        textDirection = textDirection ?? TextDirection.ltr;
 
   ScatterLabelSettings copyWith({
     bool? showLabel,
     GetLabelTextStyleFunction? getLabelTextStyleFunction,
     GetLabelFunction? getLabelFunction,
+    TextDirection? textDirection,
   }) {
     return ScatterLabelSettings(
       showLabel: showLabel ?? this.showLabel,
       getLabelTextStyleFunction:
           getLabelTextStyleFunction ?? this.getLabelTextStyleFunction,
       getLabelFunction: getLabelFunction ?? this.getLabelFunction,
+      textDirection: textDirection ?? this.textDirection,
     );
   }
 
@@ -640,6 +660,7 @@ class ScatterLabelSettings with EquatableMixin {
       showLabel: b.showLabel,
       getLabelTextStyleFunction: b.getLabelTextStyleFunction,
       getLabelFunction: b.getLabelFunction,
+      textDirection: b.textDirection,
     );
   }
 
@@ -649,5 +670,6 @@ class ScatterLabelSettings with EquatableMixin {
         showLabel,
         getLabelTextStyleFunction,
         getLabelFunction,
+        textDirection,
       ];
 }

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -197,8 +197,13 @@ class ScatterSpot extends FlSpot with EquatableMixin {
   /// You can change [show] value to show or hide the spot,
   /// [x], and [y] defines the location of spot in the [ScatterChart],
   /// [radius] defines the size of spot, and [color] defines the color of it.
-  ScatterSpot(double x, double y, {bool? show, double? radius, Color? color})
-      : show = show ?? true,
+  ScatterSpot(
+    double x,
+    double y, {
+    bool? show,
+    double? radius,
+    Color? color,
+  })  : show = show ?? true,
         radius = radius ?? 6,
         color = color ??
             Colors.primaries[((x * y) % Colors.primaries.length).toInt()],

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -194,19 +194,14 @@ class ScatterSpot extends FlSpot with EquatableMixin {
   /// Determines color of the spot.
   Color color;
 
-  /// Determines label of the spot.
-  final String label;
-
   /// You can change [show] value to show or hide the spot,
   /// [x], and [y] defines the location of spot in the [ScatterChart],
   /// [radius] defines the size of spot, and [color] defines the color of it.
-  ScatterSpot(double x, double y,
-      {bool? show, double? radius, Color? color, String? label})
+  ScatterSpot(double x, double y, {bool? show, double? radius, Color? color})
       : show = show ?? true,
         radius = radius ?? 6,
         color = color ??
             Colors.primaries[((x * y) % Colors.primaries.length).toInt()],
-        label = label ?? '',
         super(x, y);
 
   @override
@@ -216,7 +211,6 @@ class ScatterSpot extends FlSpot with EquatableMixin {
     bool? show,
     double? radius,
     Color? color,
-    String? label,
   }) {
     return ScatterSpot(
       x ?? this.x,
@@ -224,7 +218,6 @@ class ScatterSpot extends FlSpot with EquatableMixin {
       show: show ?? this.show,
       radius: radius ?? this.radius,
       color: color ?? this.color,
-      label: label ?? this.label,
     );
   }
 
@@ -236,7 +229,6 @@ class ScatterSpot extends FlSpot with EquatableMixin {
       show: b.show,
       radius: lerpDouble(a.radius, b.radius, t),
       color: Color.lerp(a.color, b.color, t),
-      label: b.label,
     );
   }
 
@@ -248,7 +240,6 @@ class ScatterSpot extends FlSpot with EquatableMixin {
         show,
         radius,
         color,
-        label,
       ];
 }
 
@@ -583,29 +574,54 @@ class ScatterChartDataTween extends Tween<ScatterChartData> {
   }
 }
 
+/// It gives you the index value of the spot and gets the text style of the label.
+typedef GetLabelTextStyleFunction = TextStyle Function(int spotIndex);
+
+/// It gives you the index value of the spot and returns the label of the spot.
+typedef GetLabelFunction = String Function(int spotIndex);
+
+/// It gives you the default text style of the label for a spot.
+TextStyle getDefaultLabelTextStyleFunction(int spotIndex) {
+  return const TextStyle();
+}
+
+/// It gives you the default label of the spot.
+String getDefaultLabelFunction(int spotIndex) {
+  return '';
+}
+
 /// Defines information about the labels in the [ScatterChart]
 class ScatterLabelSettings with EquatableMixin {
   /// Determines whether to show or hide the labels
   final bool showLabel;
 
-  /// Determines style of the labels
-  final TextStyle? textStyle;
+  /// This function gives you the index value of the spot in the list and returns the text style
+  final GetLabelTextStyleFunction getLabelTextStyleFunction;
+
+  /// This function gives you the index value of the spot in the list and returns the label.
+  final GetLabelFunction getLabelFunction;
 
   /// You can change [showLabel] value to show or hide the label,
   /// [textStyle] defines the style of label in the [ScatterChart].
   ScatterLabelSettings({
     bool? showLabel,
-    TextStyle? textStyle,
+    GetLabelTextStyleFunction? getLabelTextStyleFunction,
+    GetLabelFunction? getLabelFunction,
   })  : showLabel = showLabel ?? false,
-        textStyle = textStyle;
+        getLabelTextStyleFunction =
+            getLabelTextStyleFunction ?? getDefaultLabelTextStyleFunction,
+        getLabelFunction = getLabelFunction ?? getDefaultLabelFunction;
 
   ScatterLabelSettings copyWith({
     bool? showLabel,
-    TextStyle? textStyle,
+    GetLabelTextStyleFunction? getLabelTextStyleFunction,
+    GetLabelFunction? getLabelFunction,
   }) {
     return ScatterLabelSettings(
       showLabel: showLabel ?? this.showLabel,
-      textStyle: textStyle,
+      getLabelTextStyleFunction:
+          getLabelTextStyleFunction ?? this.getLabelTextStyleFunction,
+      getLabelFunction: getLabelFunction ?? this.getLabelFunction,
     );
   }
 
@@ -617,7 +633,8 @@ class ScatterLabelSettings with EquatableMixin {
   ) {
     return ScatterLabelSettings(
       showLabel: b.showLabel,
-      textStyle: b.textStyle,
+      getLabelTextStyleFunction: b.getLabelTextStyleFunction,
+      getLabelFunction: b.getLabelFunction,
     );
   }
 
@@ -625,6 +642,7 @@ class ScatterLabelSettings with EquatableMixin {
   @override
   List<Object?> get props => [
         showLabel,
-        textStyle,
+        getLabelTextStyleFunction,
+        getLabelFunction,
       ];
 }

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -339,19 +339,21 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
         /// if the spot is in the lower half of the chart, then draw the label either in the center or above the spot,
         /// if the spot is in upper half of the chart, then draw the label either in the center or below the spot.
         if (pixelY > centerChartY) {
-          /// if the radius of the spot is greater than the font size of the label, then draw the label inside the bubble,
-          /// else draw the label above the bubble.
-          var off = scatterSpot.radius > tp.height
-              ? tp.height / 2
-              : scatterSpot.radius;
+          /// if either the height or the width of the spot is greater than the radius of the spot, then draw the label above the bubble,
+          /// else draw the label inside the bubble.
+          var off = (scatterSpot.radius * 1.5 < tp.height ||
+                  scatterSpot.radius * 1.5 < tp.width)
+              ? scatterSpot.radius + tp.height
+              : tp.height / 2;
 
           newPixelY = pixelY - off;
         } else {
-          /// if the radius of the spot is greater than the font size of the label, then draw the label inside the bubble,
-          /// else draw the label below the bubble.
-          var off = scatterSpot.radius > tp.height
-              ? -tp.height / 2
-              : scatterSpot.radius;
+          /// if either the height or the width of the spot is greater than the radius of the spot, then draw the label below the bubble,
+          /// else draw the label inside the bubble.
+          var off = (scatterSpot.radius * 1.5 < tp.height ||
+                  scatterSpot.radius * 1.5 < tp.width)
+              ? scatterSpot.radius
+              : -tp.height / 2;
           newPixelY = pixelY + off;
         }
 

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -295,6 +295,10 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
           data.scatterLabelSettings.textStyle ?? const TextStyle();
 
       for (final scatterSpot in data.scatterSpots) {
+        if (scatterSpot.label.isEmpty) {
+          continue;
+        }
+
         final pixelX = getPixelX(scatterSpot.x, chartUsableSize, holder);
         final pixelY = getPixelY(scatterSpot.y, chartUsableSize, holder);
 

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -36,7 +36,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
     super.paint(context, canvasWrapper, holder);
     drawAxisTitles(context, canvasWrapper, holder);
     drawTitles(context, canvasWrapper, holder);
-    drawSpots(canvasWrapper, holder);
+    drawSpots(context, canvasWrapper, holder);
     drawTouchTooltips(context, canvasWrapper, holder);
   }
 
@@ -227,7 +227,10 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
 
   @visibleForTesting
   void drawSpots(
-      CanvasWrapper canvasWrapper, PaintHolder<ScatterChartData> holder) {
+    BuildContext context,
+    CanvasWrapper canvasWrapper,
+    PaintHolder<ScatterChartData> holder,
+  ) {
     final data = holder.data;
     final viewSize = canvasWrapper.size;
     final chartUsableSize = getChartUsableDrawSize(viewSize, holder);
@@ -291,10 +294,12 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
     }
 
     if (data.scatterLabelSettings.showLabel) {
-      for (final scatterSpot in data.scatterSpots) {
-        int spotIndex = data.scatterSpots.indexOf(scatterSpot);
+      for (int i = 0; i < data.scatterSpots.length; i++) {
+        final ScatterSpot scatterSpot = data.scatterSpots[i];
+        final int spotIndex = i;
 
-        String label = data.scatterLabelSettings.getLabelFunction(spotIndex);
+        String label =
+            data.scatterLabelSettings.getLabelFunction(spotIndex, scatterSpot);
 
         if (label.isEmpty || !scatterSpot.show) {
           continue;
@@ -302,13 +307,19 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
 
         final span = TextSpan(
           text: label,
-          style: data.scatterLabelSettings.getLabelTextStyleFunction(spotIndex),
+          style: Utils().getThemeAwareTextStyle(
+            context,
+            data.scatterLabelSettings.getLabelTextStyleFunction(
+              spotIndex,
+              scatterSpot,
+            ),
+          ),
         );
 
         final tp = TextPainter(
           text: span,
           textAlign: TextAlign.center,
-          textDirection: TextDirection.ltr,
+          textDirection: holder.data.scatterLabelSettings.textDirection,
           textScaleFactor: holder.textScale,
         );
 

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -295,7 +295,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
           data.scatterLabelSettings.textStyle ?? const TextStyle();
 
       for (final scatterSpot in data.scatterSpots) {
-        if (scatterSpot.label.isEmpty) {
+        if (scatterSpot.label.isEmpty || !scatterSpot.show) {
           continue;
         }
 

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -299,32 +299,6 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
           continue;
         }
 
-        final pixelX = getPixelX(scatterSpot.x, chartUsableSize, holder);
-        final pixelY = getPixelY(scatterSpot.y, chartUsableSize, holder);
-
-        double newPixelY;
-
-        double centerChartY =
-            getTopOffsetDrawSize(holder) + chartUsableSize.height / 2;
-
-        /// if the spot is in the lower half of the chart, then draw the label either in the center or above the spot,
-        /// if the spot is in upper half of the chart, then draw the label either in the center or below the spot.
-        if (pixelY > centerChartY) {
-          /// if the radius of the spot is greater than the font size of the label, then draw the label inside the bubble,
-          /// else draw the label above the bubble.
-          var off = scatterSpot.radius > (textStyle.fontSize ?? 0)
-              ? (textStyle.fontSize ?? 0) / 2
-              : scatterSpot.radius;
-
-          newPixelY = pixelY - off;
-        } else {
-          /// if the radius of the spot is greater than the font size of the label, then draw the label inside the bubble,
-          /// else draw the label below the bubble.
-          var off = scatterSpot.radius > (textStyle.fontSize ?? 0)
-              ? -(textStyle.fontSize ?? 0) / 2
-              : scatterSpot.radius;
-          newPixelY = pixelY + off;
-        }
         final span = TextSpan(
           text: scatterSpot.label,
           style: data.scatterLabelSettings.textStyle ?? const TextStyle(),
@@ -336,11 +310,42 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
           textDirection: TextDirection.ltr,
           textScaleFactor: holder.textScale,
         );
+
         tp.layout(maxWidth: chartUsableSize.width);
+
+        final pixelX = getPixelX(scatterSpot.x, chartUsableSize, holder);
+        final pixelY = getPixelY(scatterSpot.y, chartUsableSize, holder);
+
+        double newPixelY;
+
+        /// To ensure the label is centered horizontally with respect to the spot.
+        double newPixelX = pixelX - tp.width / 2;
+
+        double centerChartY =
+            getTopOffsetDrawSize(holder) + chartUsableSize.height / 2;
+
+        /// if the spot is in the lower half of the chart, then draw the label either in the center or above the spot,
+        /// if the spot is in upper half of the chart, then draw the label either in the center or below the spot.
+        if (pixelY > centerChartY) {
+          /// if the radius of the spot is greater than the font size of the label, then draw the label inside the bubble,
+          /// else draw the label above the bubble.
+          var off = scatterSpot.radius > tp.height
+              ? tp.height / 2
+              : scatterSpot.radius;
+
+          newPixelY = pixelY - off;
+        } else {
+          /// if the radius of the spot is greater than the font size of the label, then draw the label inside the bubble,
+          /// else draw the label below the bubble.
+          var off = scatterSpot.radius > tp.height
+              ? -tp.height / 2
+              : scatterSpot.radius;
+          newPixelY = pixelY + off;
+        }
 
         canvasWrapper.drawText(
           tp,
-          Offset(pixelX - tp.width / 2, newPixelY),
+          Offset(newPixelX, newPixelY),
         );
       }
     }

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -291,9 +291,6 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
     }
 
     if (data.scatterLabelSettings.showLabel) {
-      TextStyle textStyle =
-          data.scatterLabelSettings.textStyle ?? const TextStyle();
-
       for (final scatterSpot in data.scatterSpots) {
         if (scatterSpot.label.isEmpty || !scatterSpot.show) {
           continue;

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -292,13 +292,17 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
 
     if (data.scatterLabelSettings.showLabel) {
       for (final scatterSpot in data.scatterSpots) {
-        if (scatterSpot.label.isEmpty || !scatterSpot.show) {
+        int spotIndex = data.scatterSpots.indexOf(scatterSpot);
+
+        String label = data.scatterLabelSettings.getLabelFunction(spotIndex);
+
+        if (label.isEmpty || !scatterSpot.show) {
           continue;
         }
 
         final span = TextSpan(
-          text: scatterSpot.label,
-          style: data.scatterLabelSettings.textStyle ?? const TextStyle(),
+          text: label,
+          style: data.scatterLabelSettings.getLabelTextStyleFunction(spotIndex),
         );
 
         final tp = TextPainter(

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -290,6 +290,57 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       );
     }
 
+    if (data.scatterLabelSettings.showLabel) {
+      TextStyle textStyle =
+          data.scatterLabelSettings.textStyle ?? const TextStyle();
+
+      for (final scatterSpot in data.scatterSpots) {
+        final pixelX = getPixelX(scatterSpot.x, chartUsableSize, holder);
+        final pixelY = getPixelY(scatterSpot.y, chartUsableSize, holder);
+
+        double newPixelY;
+
+        double centerChartY =
+            getTopOffsetDrawSize(holder) + chartUsableSize.height / 2;
+
+        /// if the spot is in the lower half of the chart, then draw the label either in the center or above the spot,
+        /// if the spot is in upper half of the chart, then draw the label either in the center or below the spot.
+        if (pixelY > centerChartY) {
+          /// if the radius of the spot is greater than the font size of the label, then draw the label inside the bubble,
+          /// else draw the label above the bubble.
+          var off = scatterSpot.radius > (textStyle.fontSize ?? 0)
+              ? (textStyle.fontSize ?? 0) / 2
+              : scatterSpot.radius;
+
+          newPixelY = pixelY - off;
+        } else {
+          /// if the radius of the spot is greater than the font size of the label, then draw the label inside the bubble,
+          /// else draw the label below the bubble.
+          var off = scatterSpot.radius > (textStyle.fontSize ?? 0)
+              ? -(textStyle.fontSize ?? 0) / 2
+              : scatterSpot.radius;
+          newPixelY = pixelY + off;
+        }
+        final span = TextSpan(
+          text: scatterSpot.label,
+          style: data.scatterLabelSettings.textStyle ?? const TextStyle(),
+        );
+
+        final tp = TextPainter(
+          text: span,
+          textAlign: TextAlign.center,
+          textDirection: TextDirection.ltr,
+          textScaleFactor: holder.textScale,
+        );
+        tp.layout(maxWidth: chartUsableSize.width);
+
+        canvasWrapper.drawText(
+          tp,
+          Offset(pixelX - tp.width / 2, newPixelY),
+        );
+      }
+    }
+
     if (data.clipData.any) {
       canvasWrapper.restore();
     }

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2350,6 +2350,10 @@ final ScatterSpot scatterSpot2Clone = scatterSpot2.copyWith();
 final ScatterSpot scatterSpot3 = ScatterSpot(-14, 5);
 final ScatterSpot scatterSpot4 = ScatterSpot(-0, 0);
 
+String getLabel(int spotIndex) => 'label';
+TextStyle getLabelTextStyle(int spotIndex) =>
+    const TextStyle(color: Colors.green);
+
 final ScatterChartData scatterChartData1 = ScatterChartData(
     minY: 0,
     maxY: 12,
@@ -2437,7 +2441,11 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
       bottomTitles: SideTitles(showTitles: false),
     ),
     scatterLabelSettings: ScatterLabelSettings(
-        showLabel: true, textStyle: const TextStyle(color: Colors.red)));
+      showLabel: true,
+      getLabelTextStyleFunction: getLabelTextStyle,
+      getLabelFunction: getLabel,
+    ));
+
 final ScatterChartData scatterChartData1Clone = ScatterChartData(
   minY: 0,
   maxY: 12,
@@ -2525,7 +2533,10 @@ final ScatterChartData scatterChartData1Clone = ScatterChartData(
     bottomTitles: SideTitles(showTitles: false),
   ),
   scatterLabelSettings: ScatterLabelSettings(
-      showLabel: true, textStyle: const TextStyle(color: Colors.red)),
+    showLabel: true,
+    getLabelTextStyleFunction: getLabelTextStyle,
+    getLabelFunction: getLabel,
+  ),
 );
 
 final BarChartRodStackItem barChartRodStackItem1 = BarChartRodStackItem(

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2351,92 +2351,93 @@ final ScatterSpot scatterSpot3 = ScatterSpot(-14, 5);
 final ScatterSpot scatterSpot4 = ScatterSpot(-0, 0);
 
 final ScatterChartData scatterChartData1 = ScatterChartData(
-  minY: 0,
-  maxY: 12,
-  maxX: 22,
-  minX: 11,
-  axisTitleData: FlAxisTitleData(
-    show: true,
-    leftTitle: AxisTitle(
-      showTitle: true,
-      textStyle: const TextStyle(color: Colors.red, fontSize: 33),
-      textAlign: TextAlign.left,
-      reservedSize: 22,
-      margin: 11,
-      titleText: 'title 1',
-    ),
-    bottomTitle: AxisTitle(
-      showTitle: false,
-      textStyle: const TextStyle(color: Colors.grey, fontSize: 33),
-      textAlign: TextAlign.left,
-      reservedSize: 11,
-      margin: 11,
-      titleText: 'title 2',
-    ),
-    rightTitle: AxisTitle(
-      showTitle: false,
-      textStyle: const TextStyle(color: Colors.blue, fontSize: 11),
-      textAlign: TextAlign.left,
-      reservedSize: 2,
-      margin: 1324,
-      titleText: 'title 3',
-    ),
-    topTitle: AxisTitle(
-      showTitle: true,
-      textStyle: const TextStyle(color: Colors.green, fontSize: 33),
-      textAlign: TextAlign.left,
-      reservedSize: 23,
-      margin: 11,
-      titleText: 'title 4',
-    ),
-  ),
-  gridData: FlGridData(
-    show: false,
-    getDrawingHorizontalLine: gridGetDrawingLine,
-    getDrawingVerticalLine: gridGetDrawingLine,
-    checkToShowHorizontalLine: gridCheckToShowLine,
-    checkToShowVerticalLine: gridCheckToShowLine,
-    drawHorizontalLine: true,
-    drawVerticalLine: false,
-    horizontalInterval: 33,
-    verticalInterval: 1,
-  ),
-  backgroundColor: Colors.black,
-  clipData: FlClipData.none(),
-  borderData: FlBorderData(
+    minY: 0,
+    maxY: 12,
+    maxX: 22,
+    minX: 11,
+    axisTitleData: FlAxisTitleData(
       show: true,
-      border: Border.all(
-        color: Colors.white,
-      )),
-  scatterSpots: [
-    ScatterSpot(0, 0, show: false, radius: 33, color: Colors.yellow),
-    ScatterSpot(2, 2, show: false, radius: 11, color: Colors.purple),
-    ScatterSpot(1, 2, show: false, radius: 11, color: Colors.white),
-  ],
-  scatterTouchData: ScatterTouchData(
-    enabled: true,
-    touchTooltipData: ScatterTouchTooltipData(
-      getTooltipItems: scatterChartGetTooltipItems,
-      fitInsideHorizontally: true,
-      fitInsideVertically: false,
-      maxContentWidth: 33,
-      tooltipBgColor: Colors.white,
-      tooltipPadding: const EdgeInsets.all(23),
-      tooltipRoundedRadius: 534,
+      leftTitle: AxisTitle(
+        showTitle: true,
+        textStyle: const TextStyle(color: Colors.red, fontSize: 33),
+        textAlign: TextAlign.left,
+        reservedSize: 22,
+        margin: 11,
+        titleText: 'title 1',
+      ),
+      bottomTitle: AxisTitle(
+        showTitle: false,
+        textStyle: const TextStyle(color: Colors.grey, fontSize: 33),
+        textAlign: TextAlign.left,
+        reservedSize: 11,
+        margin: 11,
+        titleText: 'title 2',
+      ),
+      rightTitle: AxisTitle(
+        showTitle: false,
+        textStyle: const TextStyle(color: Colors.blue, fontSize: 11),
+        textAlign: TextAlign.left,
+        reservedSize: 2,
+        margin: 1324,
+        titleText: 'title 3',
+      ),
+      topTitle: AxisTitle(
+        showTitle: true,
+        textStyle: const TextStyle(color: Colors.green, fontSize: 33),
+        textAlign: TextAlign.left,
+        reservedSize: 23,
+        margin: 11,
+        titleText: 'title 4',
+      ),
     ),
-    handleBuiltInTouches: false,
-    touchCallback: scatterTouchCallback,
-    touchSpotThreshold: 12,
-  ),
-  showingTooltipIndicators: [0, 1, 2],
-  titlesData: FlTitlesData(
-    show: true,
-    leftTitles: SideTitles(showTitles: false),
-    rightTitles: SideTitles(reservedSize: 100, margin: 400, showTitles: true),
-    topTitles: SideTitles(showTitles: false),
-    bottomTitles: SideTitles(showTitles: false),
-  ),
-);
+    gridData: FlGridData(
+      show: false,
+      getDrawingHorizontalLine: gridGetDrawingLine,
+      getDrawingVerticalLine: gridGetDrawingLine,
+      checkToShowHorizontalLine: gridCheckToShowLine,
+      checkToShowVerticalLine: gridCheckToShowLine,
+      drawHorizontalLine: true,
+      drawVerticalLine: false,
+      horizontalInterval: 33,
+      verticalInterval: 1,
+    ),
+    backgroundColor: Colors.black,
+    clipData: FlClipData.none(),
+    borderData: FlBorderData(
+        show: true,
+        border: Border.all(
+          color: Colors.white,
+        )),
+    scatterSpots: [
+      ScatterSpot(0, 0, show: false, radius: 33, color: Colors.yellow),
+      ScatterSpot(2, 2, show: false, radius: 11, color: Colors.purple),
+      ScatterSpot(1, 2, show: false, radius: 11, color: Colors.white),
+    ],
+    scatterTouchData: ScatterTouchData(
+      enabled: true,
+      touchTooltipData: ScatterTouchTooltipData(
+        getTooltipItems: scatterChartGetTooltipItems,
+        fitInsideHorizontally: true,
+        fitInsideVertically: false,
+        maxContentWidth: 33,
+        tooltipBgColor: Colors.white,
+        tooltipPadding: const EdgeInsets.all(23),
+        tooltipRoundedRadius: 534,
+      ),
+      handleBuiltInTouches: false,
+      touchCallback: scatterTouchCallback,
+      touchSpotThreshold: 12,
+    ),
+    showingTooltipIndicators: [0, 1, 2],
+    titlesData: FlTitlesData(
+      show: true,
+      leftTitles: SideTitles(showTitles: false),
+      rightTitles: SideTitles(reservedSize: 100, margin: 400, showTitles: true),
+      topTitles: SideTitles(showTitles: false),
+      bottomTitles: SideTitles(showTitles: false),
+    ),
+    scatterLabelSettings: ScatterLabelSettings(
+        showLabel: true, textStyle: const TextStyle(color: Colors.red)));
 final ScatterChartData scatterChartData1Clone = ScatterChartData(
   minY: 0,
   maxY: 12,
@@ -2523,6 +2524,8 @@ final ScatterChartData scatterChartData1Clone = ScatterChartData(
     topTitles: SideTitles(showTitles: false),
     bottomTitles: SideTitles(showTitles: false),
   ),
+  scatterLabelSettings: ScatterLabelSettings(
+      showLabel: true, textStyle: const TextStyle(color: Colors.red)),
 );
 
 final BarChartRodStackItem barChartRodStackItem1 = BarChartRodStackItem(

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2350,8 +2350,8 @@ final ScatterSpot scatterSpot2Clone = scatterSpot2.copyWith();
 final ScatterSpot scatterSpot3 = ScatterSpot(-14, 5);
 final ScatterSpot scatterSpot4 = ScatterSpot(-0, 0);
 
-String getLabel(int spotIndex) => 'label';
-TextStyle getLabelTextStyle(int spotIndex) =>
+String getLabel(int spotIndex, ScatterSpot spot) => 'label';
+TextStyle getLabelTextStyle(int spotIndex, ScatterSpot spot) =>
     const TextStyle(color: Colors.green);
 
 final ScatterChartData scatterChartData1 = ScatterChartData(

--- a/test/chart/scatter_chart/scatter_chart_data_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_data_test.dart
@@ -304,15 +304,41 @@ void main() {
               scatterChartData1Clone
                   .copyWith(showingTooltipIndicators: [2, 1, 0]),
           false);
+
+      expect(
+          scatterChartData1 ==
+              scatterChartData1Clone.copyWith(
+                  scatterLabelSettings: ScatterLabelSettings(
+                      showLabel: true,
+                      textStyle: const TextStyle(color: Colors.green))),
+          false);
+
+      expect(
+          scatterChartData1 ==
+              scatterChartData1Clone.copyWith(
+                  scatterLabelSettings: ScatterLabelSettings(
+                      showLabel: false,
+                      textStyle: const TextStyle(color: Colors.red))),
+          false);
+
+      expect(
+          scatterChartData1 ==
+              scatterChartData1Clone.copyWith(
+                  scatterLabelSettings: ScatterLabelSettings(
+                      showLabel: true,
+                      textStyle: const TextStyle(color: Colors.red))),
+          true);
     });
 
     test('ScatterSpot equality test', () {
-      final ScatterSpot scatterSpot = ScatterSpot(0, 1);
-      final ScatterSpot scatterSpotClone = ScatterSpot(0, 1);
+      final ScatterSpot scatterSpot = ScatterSpot(0, 1, label: 'label');
+      final ScatterSpot scatterSpotClone = ScatterSpot(0, 1, label: 'label');
 
       expect(scatterSpot == scatterSpotClone.copyWith(), true);
       expect(scatterSpot == scatterSpotClone.copyWith(y: 3), false);
       expect(scatterSpot == scatterSpotClone.copyWith(x: 3), false);
+      expect(scatterSpot == scatterSpotClone.copyWith(label: ''), false);
+      expect(scatterSpot == scatterSpotClone.copyWith(label: 'label'), true);
     });
 
     test('ScatterTouchData equality test', () {
@@ -419,6 +445,32 @@ void main() {
         'aa',
         textStyle: const TextStyle(color: Colors.red),
         bottomMargin: 0,
+      );
+      expect(sample1 == changed, false);
+    });
+
+    test('ScatterLabelSettings equality test', () {
+      final ScatterLabelSettings sample1 = ScatterLabelSettings(
+        showLabel: true,
+        textStyle: const TextStyle(color: Colors.red),
+      );
+      final ScatterLabelSettings sample2 = ScatterLabelSettings(
+        showLabel: true,
+        textStyle: const TextStyle(color: Colors.red),
+      );
+      expect(sample1 == sample2, true);
+
+      ScatterLabelSettings changed = ScatterLabelSettings(
+        showLabel: false,
+        textStyle: const TextStyle(color: Colors.red),
+      );
+      expect(sample1 == changed, false);
+
+      expect(sample1 == changed.copyWith(showLabel: true), false);
+
+      changed = ScatterLabelSettings(
+        showLabel: true,
+        textStyle: const TextStyle(color: Colors.green),
       );
       expect(sample1 == changed, false);
     });

--- a/test/chart/scatter_chart/scatter_chart_data_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_data_test.dart
@@ -310,7 +310,7 @@ void main() {
               scatterChartData1Clone.copyWith(
                   scatterLabelSettings: ScatterLabelSettings(
                 showLabel: true,
-                getLabelTextStyleFunction: (int index) =>
+                getLabelTextStyleFunction: (int index, ScatterSpot spot) =>
                     const TextStyle(color: Colors.green),
               )),
           false);
@@ -320,9 +320,10 @@ void main() {
               scatterChartData1Clone.copyWith(
                   scatterLabelSettings: ScatterLabelSettings(
                 showLabel: false,
-                getLabelTextStyleFunction: (int index) =>
+                getLabelTextStyleFunction: (int index, ScatterSpot spot) =>
                     const TextStyle(color: Colors.red),
-                getLabelFunction: (int index) => 'Label - $index',
+                getLabelFunction: (int index, ScatterSpot spot) =>
+                    'Label - $index',
               )),
           false);
 
@@ -331,9 +332,10 @@ void main() {
               scatterChartData1Clone.copyWith(
                   scatterLabelSettings: ScatterLabelSettings(
                 showLabel: true,
-                getLabelTextStyleFunction: (int index) =>
+                getLabelTextStyleFunction: (int index, ScatterSpot spot) =>
                     const TextStyle(color: Colors.red),
-                getLabelFunction: (int index) => 'Different Label - $index',
+                getLabelFunction: (int index, ScatterSpot spot) =>
+                    'Different Label - $index',
               )),
           false);
 
@@ -346,6 +348,17 @@ void main() {
                 getLabelTextStyleFunction: getLabelTextStyle,
               )),
           true);
+
+      expect(
+          scatterChartData1 ==
+              scatterChartData1Clone.copyWith(
+                  scatterLabelSettings: ScatterLabelSettings(
+                showLabel: true,
+                getLabelFunction: getLabel,
+                getLabelTextStyleFunction: getLabelTextStyle,
+                textDirection: TextDirection.rtl,
+              )),
+          false);
     });
 
     test('ScatterSpot equality test', () {
@@ -490,7 +503,15 @@ void main() {
       changed = ScatterLabelSettings(
         showLabel: true,
         getLabelTextStyleFunction: getLabelTextStyle,
-        getLabelFunction: (int index) => 'Label',
+        getLabelFunction: (int index, ScatterSpot spot) => 'Label',
+      );
+      expect(sample1 == changed, false);
+
+      changed = ScatterLabelSettings(
+        showLabel: true,
+        getLabelTextStyleFunction: getLabelTextStyle,
+        getLabelFunction: getLabel,
+        textDirection: TextDirection.rtl,
       );
       expect(sample1 == changed, false);
     });

--- a/test/chart/scatter_chart/scatter_chart_data_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_data_test.dart
@@ -309,36 +309,52 @@ void main() {
           scatterChartData1 ==
               scatterChartData1Clone.copyWith(
                   scatterLabelSettings: ScatterLabelSettings(
-                      showLabel: true,
-                      textStyle: const TextStyle(color: Colors.green))),
+                showLabel: true,
+                getLabelTextStyleFunction: (int index) =>
+                    const TextStyle(color: Colors.green),
+              )),
           false);
 
       expect(
           scatterChartData1 ==
               scatterChartData1Clone.copyWith(
                   scatterLabelSettings: ScatterLabelSettings(
-                      showLabel: false,
-                      textStyle: const TextStyle(color: Colors.red))),
+                showLabel: false,
+                getLabelTextStyleFunction: (int index) =>
+                    const TextStyle(color: Colors.red),
+                getLabelFunction: (int index) => 'Label - $index',
+              )),
           false);
 
       expect(
           scatterChartData1 ==
               scatterChartData1Clone.copyWith(
                   scatterLabelSettings: ScatterLabelSettings(
-                      showLabel: true,
-                      textStyle: const TextStyle(color: Colors.red))),
+                showLabel: true,
+                getLabelTextStyleFunction: (int index) =>
+                    const TextStyle(color: Colors.red),
+                getLabelFunction: (int index) => 'Different Label - $index',
+              )),
+          false);
+
+      expect(
+          scatterChartData1 ==
+              scatterChartData1Clone.copyWith(
+                  scatterLabelSettings: ScatterLabelSettings(
+                showLabel: true,
+                getLabelFunction: getLabel,
+                getLabelTextStyleFunction: getLabelTextStyle,
+              )),
           true);
     });
 
     test('ScatterSpot equality test', () {
-      final ScatterSpot scatterSpot = ScatterSpot(0, 1, label: 'label');
-      final ScatterSpot scatterSpotClone = ScatterSpot(0, 1, label: 'label');
+      final ScatterSpot scatterSpot = ScatterSpot(0, 1);
+      final ScatterSpot scatterSpotClone = ScatterSpot(0, 1);
 
       expect(scatterSpot == scatterSpotClone.copyWith(), true);
       expect(scatterSpot == scatterSpotClone.copyWith(y: 3), false);
       expect(scatterSpot == scatterSpotClone.copyWith(x: 3), false);
-      expect(scatterSpot == scatterSpotClone.copyWith(label: ''), false);
-      expect(scatterSpot == scatterSpotClone.copyWith(label: 'label'), true);
     });
 
     test('ScatterTouchData equality test', () {
@@ -452,25 +468,29 @@ void main() {
     test('ScatterLabelSettings equality test', () {
       final ScatterLabelSettings sample1 = ScatterLabelSettings(
         showLabel: true,
-        textStyle: const TextStyle(color: Colors.red),
+        getLabelTextStyleFunction: getLabelTextStyle,
+        getLabelFunction: getLabel,
       );
       final ScatterLabelSettings sample2 = ScatterLabelSettings(
         showLabel: true,
-        textStyle: const TextStyle(color: Colors.red),
+        getLabelTextStyleFunction: getLabelTextStyle,
+        getLabelFunction: getLabel,
       );
       expect(sample1 == sample2, true);
 
       ScatterLabelSettings changed = ScatterLabelSettings(
         showLabel: false,
-        textStyle: const TextStyle(color: Colors.red),
+        getLabelTextStyleFunction: getLabelTextStyle,
+        getLabelFunction: getLabel,
       );
       expect(sample1 == changed, false);
 
-      expect(sample1 == changed.copyWith(showLabel: true), false);
+      expect(sample1 == changed.copyWith(showLabel: true), true);
 
       changed = ScatterLabelSettings(
         showLabel: true,
-        textStyle: const TextStyle(color: Colors.green),
+        getLabelTextStyleFunction: getLabelTextStyle,
+        getLabelFunction: (int index) => 'Label',
       );
       expect(sample1 == changed, false);
     });

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -444,6 +444,7 @@ void main() {
       verify(_mockCanvasWrapper.drawCircle(const Offset(70, 50), 6, any))
           .called(1);
 
+      verifyNever(_mockCanvasWrapper.drawText(any, any));
       verify(_mockCanvasWrapper.clipRect(any)).called(1);
     });
 
@@ -477,6 +478,57 @@ void main() {
 
       verifyNever(_mockCanvasWrapper.drawCircle(any, any, any));
       verifyNever(_mockCanvasWrapper.clipRect(any));
+
+      verifyNever(_mockCanvasWrapper.drawText(any, any));
+    });
+
+    test('test 3', () {
+      const viewSize = Size(100, 100);
+
+      final ScatterChartData data = ScatterChartData(
+          minY: 0,
+          maxY: 10,
+          minX: 0,
+          maxX: 10,
+          scatterSpots: [
+            ScatterSpot(1, 1, radius: 18, label: '1,1'),
+            ScatterSpot(2, 2, radius: 8, label: '2,2'),
+            ScatterSpot(3, 9, show: false, label: '3,9'),
+            ScatterSpot(8, 8, radius: 4, label: '8,8'),
+            ScatterSpot(7, 5, radius: 20, label: ''),
+            ScatterSpot(4, 6, radius: 24, label: '4,6'),
+          ],
+          titlesData: FlTitlesData(show: false),
+          clipData: FlClipData.all(),
+          scatterLabelSettings: ScatterLabelSettings(
+            showLabel: true,
+            textStyle: const TextStyle(fontSize: 10),
+          ));
+
+      final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
+      final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
+      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
+      when(_mockCanvasWrapper.size).thenReturn(viewSize);
+      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      scatterChartPainter.drawSpots(
+        _mockCanvasWrapper,
+        holder,
+      );
+
+      verify(_mockCanvasWrapper.drawCircle(const Offset(10, 90), 18, any))
+          .called(1);
+      verify(_mockCanvasWrapper.drawCircle(const Offset(20, 80), 8, any))
+          .called(1);
+      verify(_mockCanvasWrapper.drawCircle(const Offset(80, 20), 4, any))
+          .called(1);
+      verify(_mockCanvasWrapper.drawCircle(const Offset(70, 50), 20, any))
+          .called(1);
+      verify(_mockCanvasWrapper.drawCircle(const Offset(40, 40), 24, any))
+          .called(1);
+
+      verify(_mockCanvasWrapper.drawText(any, any)).called(4);
+
+      verify(_mockCanvasWrapper.clipRect(any)).called(1);
     });
   });
 

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -491,18 +491,25 @@ void main() {
           minX: 0,
           maxX: 10,
           scatterSpots: [
-            ScatterSpot(1, 1, radius: 18, label: '1,1'),
-            ScatterSpot(2, 2, radius: 8, label: '2,2'),
-            ScatterSpot(3, 9, show: false, label: '3,9'),
-            ScatterSpot(8, 8, radius: 4, label: '8,8'),
-            ScatterSpot(7, 5, radius: 20, label: ''),
-            ScatterSpot(4, 6, radius: 24, label: '4,6'),
+            ScatterSpot(1, 1, radius: 18),
+            ScatterSpot(2, 2, radius: 8),
+            ScatterSpot(3, 9, show: false),
+            ScatterSpot(8, 8, radius: 4),
+            ScatterSpot(7, 5, radius: 20),
+            ScatterSpot(4, 6, radius: 24),
           ],
           titlesData: FlTitlesData(show: false),
           clipData: FlClipData.all(),
           scatterLabelSettings: ScatterLabelSettings(
             showLabel: true,
-            textStyle: const TextStyle(fontSize: 10),
+            getLabelTextStyleFunction: (int index) =>
+                const TextStyle(fontSize: 12),
+            getLabelFunction: (int index) {
+              if (index == 5) {
+                return '';
+              }
+              return 'Label : $index';
+            },
           ));
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -429,10 +429,13 @@ void main() {
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
+
+      MockBuildContext _mockBuildContext = MockBuildContext();
       MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
       when(_mockCanvasWrapper.size).thenReturn(viewSize);
       when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawSpots(
+        _mockBuildContext,
         _mockCanvasWrapper,
         holder,
       );
@@ -468,10 +471,13 @@ void main() {
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
+
+      MockBuildContext _mockBuildContext = MockBuildContext();
       MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
       when(_mockCanvasWrapper.size).thenReturn(viewSize);
       when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawSpots(
+        _mockBuildContext,
         _mockCanvasWrapper,
         holder,
       );
@@ -502,9 +508,9 @@ void main() {
           clipData: FlClipData.all(),
           scatterLabelSettings: ScatterLabelSettings(
             showLabel: true,
-            getLabelTextStyleFunction: (int index) =>
+            getLabelTextStyleFunction: (int index, ScatterSpot spot) =>
                 const TextStyle(fontSize: 12),
-            getLabelFunction: (int index) {
+            getLabelFunction: (int index, ScatterSpot spot) {
               if (index == 5) {
                 return '';
               }
@@ -514,10 +520,13 @@ void main() {
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
+
+      MockBuildContext _mockBuildContext = MockBuildContext();
       MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
       when(_mockCanvasWrapper.size).thenReturn(viewSize);
       when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawSpots(
+        _mockBuildContext,
         _mockCanvasWrapper,
         holder,
       );

--- a/test/chart/scatter_chart/scatter_chart_renderer_test.mocks.dart
+++ b/test/chart/scatter_chart/scatter_chart_renderer_test.mocks.dart
@@ -487,9 +487,10 @@ class MockScatterChartPainter extends _i1.Mock
           Invocation.method(#drawTitles, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawSpots(_i10.CanvasWrapper? canvasWrapper,
+  void drawSpots(_i6.BuildContext? context, _i10.CanvasWrapper? canvasWrapper,
           _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
-      super.noSuchMethod(Invocation.method(#drawSpots, [canvasWrapper, holder]),
+      super.noSuchMethod(
+          Invocation.method(#drawSpots, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
   void drawTouchTooltips(


### PR DESCRIPTION
fix #902 
1. Allows giving `label` to `ScatterSpot` in Scatter Chart.
2. Draws the label based on the `ScatterLabelSettings` provided.