### PR TITLE
Sort the scatter spots before drawing.

### DIFF
--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -277,7 +277,10 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       canvasWrapper.clipRect(Rect.fromLTRB(left, top, right, bottom));
     }
 
-    for (final scatterSpot in data.scatterSpots) {
+    List<ScatterSpot> sortedSpots = data.scatterSpots.toList()
+      ..sort((ScatterSpot a, ScatterSpot b) => b.radius.compareTo(a.radius));
+
+    for (final scatterSpot in sortedSpots) {
       if (!scatterSpot.show) {
         continue;
       }


### PR DESCRIPTION
The scatter spots are sorted in decreasing order of the radius so that the spot with the larger radius is drawn first.