### PR TITLE
Add option to enable rounded corners for pie charts

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -23,6 +23,14 @@ class PieChartData extends BaseChartData with EquatableMixin {
   /// Defines gap between sections.
   final double sectionsSpace;
 
+  /// Defines the degrees to which cut back with rounded corners.
+  /// [roundedCornerRadius] must also be set for this to work.
+  final double roundedCornerDegrees;
+
+  /// Defines the radius of the arc of the rounded corners.
+  /// [roundedCornerDegrees] must also be set for this to work.
+  final double roundedCornerRadius;
+
   /// [PieChart] draws [sections] from zero degree (right side of the circle) clockwise.
   final double startDegreeOffset;
 
@@ -50,6 +58,8 @@ class PieChartData extends BaseChartData with EquatableMixin {
     double? centerSpaceRadius,
     Color? centerSpaceColor,
     double? sectionsSpace,
+    double? roundedCornerDegrees,
+    double? roundedCornerRadius,
     double? startDegreeOffset,
     PieTouchData? pieTouchData,
     FlBorderData? borderData,
@@ -58,6 +68,8 @@ class PieChartData extends BaseChartData with EquatableMixin {
         centerSpaceRadius = centerSpaceRadius ?? double.infinity,
         centerSpaceColor = centerSpaceColor ?? Colors.transparent,
         sectionsSpace = sectionsSpace ?? 2,
+        roundedCornerDegrees = roundedCornerDegrees ?? 0,
+        roundedCornerRadius = roundedCornerRadius ?? 0,
         startDegreeOffset = startDegreeOffset ?? 0,
         pieTouchData = pieTouchData ?? PieTouchData(),
         super(
@@ -72,6 +84,8 @@ class PieChartData extends BaseChartData with EquatableMixin {
     double? centerSpaceRadius,
     Color? centerSpaceColor,
     double? sectionsSpace,
+    double? roundedCornerDegrees,
+    double? roundedCornerRadius,
     double? startDegreeOffset,
     PieTouchData? pieTouchData,
     FlBorderData? borderData,
@@ -81,6 +95,8 @@ class PieChartData extends BaseChartData with EquatableMixin {
       centerSpaceRadius: centerSpaceRadius ?? this.centerSpaceRadius,
       centerSpaceColor: centerSpaceColor ?? this.centerSpaceColor,
       sectionsSpace: sectionsSpace ?? this.sectionsSpace,
+      roundedCornerDegrees: roundedCornerDegrees ?? this.roundedCornerDegrees,
+      roundedCornerRadius: roundedCornerRadius ?? this.roundedCornerRadius,
       startDegreeOffset: startDegreeOffset ?? this.startDegreeOffset,
       pieTouchData: pieTouchData ?? this.pieTouchData,
       borderData: borderData ?? this.borderData,
@@ -98,6 +114,8 @@ class PieChartData extends BaseChartData with EquatableMixin {
             a.centerSpaceRadius, b.centerSpaceRadius, t),
         pieTouchData: b.pieTouchData,
         sectionsSpace: lerpDouble(a.sectionsSpace, b.sectionsSpace, t),
+        roundedCornerDegrees: lerpDouble(a.roundedCornerDegrees, b.roundedCornerDegrees, t),
+        roundedCornerRadius: lerpDouble(a.roundedCornerRadius, b.roundedCornerRadius, t),
         startDegreeOffset:
             lerpDouble(a.startDegreeOffset, b.startDegreeOffset, t),
         sections: lerpPieChartSectionDataList(a.sections, b.sections, t),
@@ -115,6 +133,8 @@ class PieChartData extends BaseChartData with EquatableMixin {
         centerSpaceColor,
         pieTouchData,
         sectionsSpace,
+        roundedCornerDegrees,
+        roundedCornerRadius,
         startDegreeOffset,
         borderData,
       ];


### PR DESCRIPTION
Let me know if you find this useful:
This adds the option to set the edges of a pie chart rounded.