### PR TITLE
Bump version to 0.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## newVersion 
+## 0.50.1 
 * **BUGFIX** Allow to show axisTitle without sideTitles, #963
 
 ## 0.50.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A powerful Flutter chart library, currently supporting Line Chart, Bar Chart and Pie Chart.
-version: 0.50.0
+version: 0.50.1
 homepage: https://github.com/imaNNeoFighT/fl_chart
 
 environment:


### PR DESCRIPTION
* **BUGFIX** Allow to show axisTitle without sideTitles, #963
