### PR TITLE
Update stable to 0.50.4

### DIFF
--- a/ .codecov.yml
+++ b/ .codecov.yml
@@ -7,10 +7,6 @@ coverage:
       default:
         target: 85%
         threshold: 2%
-    patch:
-      default:
-        target: 85%
-        threshold: 5%
   precision: 1
   range: "80...100"
 

--- a/ .codecov.yml
+++ b/ .codecov.yml
@@ -7,6 +7,10 @@ coverage:
       default:
         target: 85%
         threshold: 2%
+    patch:
+      default:
+        target: 0%
+        threshold: 5%
   precision: 1
   range: "80...100"
 

--- a/ .codecov.yml
+++ b/ .codecov.yml
@@ -2,6 +2,15 @@ comment:
   require_changes: true
 
 coverage:
+  status:
+    project:
+      default:
+        target: 85%
+        threshold: 2%
+    patch:
+      default:
+        target: 85%
+        threshold: 5%
   precision: 1
   range: "80...100"
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
           channel: "stable"
       - name: Get packages

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
           channel: "stable"
       - name: Get packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## newVersion
 * **IMPROVEMENT** Fix order of drawing lineChart bar indicator problem, #198.
+* **FEATURE** Add `isStrokeJoinRound` property in [LineChartBarData](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md).
 
 ## 0.50.1 
 * **BUGFIX** Allow to show axisTitle without sideTitles, #963

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## newVersion
+## 0.50.3
 * **IMPROVEMENT** Fix order of drawing lineChart bar indicator problem, #198.
 * **FEATURE** Add `isStrokeJoinRound` property in [LineChartBarData](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#linechartbardata).
 * **IMPROVEMENT** Upgrade to Flutter 3, #997.
-* **FEATURE** Add 'chartRendererKey' property to the [LineChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md), [BarChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/bar_chart.md), and [ScatterChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/scatter_chart.md). We pass it directly to our chart renderers that are responsible to render the chart itself (without anything around it like titles), #987.
+* **FEATURE** Add `chartRendererKey` property to the [LineChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md), [BarChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/bar_chart.md), and [ScatterChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/scatter_chart.md). We pass it directly to our chart renderers that are responsible to render the chart itself (without anything around it like titles), #987.
 
 ## 0.50.1 
 * **BUGFIX** Allow to show axisTitle without sideTitles, #963

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## newVersion
+* **IMPROVEMENT** Fix order of drawing lineChart bar indicator problem, #198.
+
 ## 0.50.1 
 * **BUGFIX** Allow to show axisTitle without sideTitles, #963
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## newVersion
 * **IMPROVEMENT** Fix order of drawing lineChart bar indicator problem, #198.
 * **FEATURE** Add `isStrokeJoinRound` property in [LineChartBarData](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#linechartbardata).
+* **IMPROVEMENT** Upgrade to Flutter 3, #997.
 
 ## 0.50.1 
 * **BUGFIX** Allow to show axisTitle without sideTitles, #963

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **IMPROVEMENT** Fix order of drawing lineChart bar indicator problem, #198.
 * **FEATURE** Add `isStrokeJoinRound` property in [LineChartBarData](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#linechartbardata).
 * **IMPROVEMENT** Upgrade to Flutter 3, #997.
+* **FEATURE** Add 'chartRendererKey' property to the [LineChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md), [BarChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/bar_chart.md), and [ScatterChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/scatter_chart.md). We pass it directly to our chart renderers that are responsible to render the chart itself (without anything around it like titles), #987.
 
 ## 0.50.1 
 * **BUGFIX** Allow to show axisTitle without sideTitles, #963

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.50.5
+* **IMPROVEMENT** Fix test coverage problem again :/
+
 ## 0.50.4
 * **IMPROVEMENT** Fix test coverage problem 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## newVersion
 * **IMPROVEMENT** Fix order of drawing lineChart bar indicator problem, #198.
-* **FEATURE** Add `isStrokeJoinRound` property in [LineChartBarData](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md).
+* **FEATURE** Add `isStrokeJoinRound` property in [LineChartBarData](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#linechartbardata).
 
 ## 0.50.1 
 * **BUGFIX** Allow to show axisTitle without sideTitles, #963

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.50.4
+* **IMPROVEMENT** Fix test coverage problem 
+
 ## 0.50.3
 * **IMPROVEMENT** Fix order of drawing lineChart bar indicator problem, #198.
 * **FEATURE** Add `isStrokeJoinRound` property in [LineChartBarData](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#linechartbardata).

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,6 @@ showTestCoverage:
 	flutter test --coverage
 	genhtml coverage/lcov.info -o coverage/html
 	source ./scripts/makefile_scripts.sh && open_link "coverage/html/index.html"
+
+buildRunner:
+	flutter packages pub run build_runner build --delete-conflicting-outputs

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,7 @@ analyzer:
   exclude:
     - "**.mocks.dart"
   errors:
+    library_private_types_in_public_api: ignore
     prefer_initializing_formals: ignore
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -13,3 +16,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -13,3 +16,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/lib/src/chart/bar_chart/bar_chart.dart
+++ b/lib/src/chart/bar_chart/bar_chart.dart
@@ -8,6 +8,10 @@ class BarChart extends ImplicitlyAnimatedWidget {
   /// Determines how the [BarChart] should be look like.
   final BarChartData data;
 
+  /// We pass this key to our renderers which are supposed to
+  /// render the chart itself (without anything around the chart).
+  final Key? chartRendererKey;
+
   /// [data] determines how the [BarChart] should be look like,
   /// when you make any change in the [BarChartData], it updates
   /// new values with animation, and duration is [swapAnimationDuration].
@@ -15,6 +19,7 @@ class BarChart extends ImplicitlyAnimatedWidget {
   /// which default is [Curves.linear].
   const BarChart(
     this.data, {
+    this.chartRendererKey,
     Key? key,
     Duration swapAnimationDuration = const Duration(milliseconds: 150),
     Curve swapAnimationCurve = Curves.linear,
@@ -48,6 +53,7 @@ class _BarChartState extends AnimatedWidgetBaseState<BarChart> {
       chart: BarChartLeaf(
         data: _withTouchedIndicators(_barChartDataTween!.evaluate(animation)),
         targetData: _withTouchedIndicators(showingData),
+        key: widget.chartRendererKey,
       ),
     );
   }

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -350,9 +350,7 @@ class FlSpot with EquatableMixin {
 
   ///Prints x and y coordinates of FlSpot list
   @override
-  String toString() {
-    return '(' + x.toString() + ', ' + y.toString() + ')';
-  }
+  String toString() => '($x, $y)';
 
   /// Used for splitting lines, or maybe other concepts.
   static const FlSpot nullSpot = FlSpot(double.nan, double.nan);

--- a/lib/src/chart/line_chart/line_chart.dart
+++ b/lib/src/chart/line_chart/line_chart.dart
@@ -10,6 +10,10 @@ class LineChart extends ImplicitlyAnimatedWidget {
   /// Determines how the [LineChart] should be look like.
   final LineChartData data;
 
+  /// We pass this key to our renderers which are supposed to
+  /// render the chart itself (without anything around the chart).
+  final Key? chartRendererKey;
+
   /// [data] determines how the [LineChart] should be look like,
   /// when you make any change in the [LineChartData], it updates
   /// new values with animation, and duration is [swapAnimationDuration].
@@ -17,6 +21,7 @@ class LineChart extends ImplicitlyAnimatedWidget {
   /// which default is [Curves.linear].
   const LineChart(
     this.data, {
+    this.chartRendererKey,
     Key? key,
     Duration swapAnimationDuration = const Duration(milliseconds: 150),
     Curve swapAnimationCurve = Curves.linear,
@@ -51,6 +56,7 @@ class _LineChartState extends AnimatedWidgetBaseState<LineChart> {
       chart: LineChartLeaf(
         data: _withTouchedIndicators(_lineChartDataTween!.evaluate(animation)),
         targetData: _withTouchedIndicators(showingData),
+        key: widget.chartRendererKey,
       ),
       data: showingData,
     );

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -256,6 +256,9 @@ class LineChartBarData with EquatableMixin {
   /// Determines the style of line's cap.
   final bool isStrokeCapRound;
 
+  /// Determines the style of line joins.
+  final bool isStrokeJoinRound;
+
   /// Fills the space blow the line, using a color or gradient.
   final BarAreaData belowBarData;
 
@@ -305,6 +308,8 @@ class LineChartBarData with EquatableMixin {
   ///
   /// [isStrokeCapRound] determines the shape of line's cap.
   ///
+  /// [isStrokeJoinRound] determines the shape of the line joins.
+  ///
   /// [belowBarData], and  [aboveBarData] used to fill the space below or above the drawn line,
   /// you can fill with a solid color or a linear gradient.
   ///
@@ -330,6 +335,7 @@ class LineChartBarData with EquatableMixin {
     bool? preventCurveOverShooting,
     double? preventCurveOvershootingThreshold,
     bool? isStrokeCapRound,
+    bool? isStrokeJoinRound,
     BarAreaData? belowBarData,
     BarAreaData? aboveBarData,
     FlDotData? dotData,
@@ -350,6 +356,7 @@ class LineChartBarData with EquatableMixin {
         preventCurveOvershootingThreshold =
             preventCurveOvershootingThreshold ?? 10.0,
         isStrokeCapRound = isStrokeCapRound ?? false,
+        isStrokeJoinRound = isStrokeJoinRound ?? false,
         belowBarData = belowBarData ?? BarAreaData(),
         aboveBarData = aboveBarData ?? BarAreaData(),
         dotData = dotData ?? FlDotData(),
@@ -406,6 +413,7 @@ class LineChartBarData with EquatableMixin {
       curveSmoothness: b.curveSmoothness,
       isCurved: b.isCurved,
       isStrokeCapRound: b.isStrokeCapRound,
+      isStrokeJoinRound: b.isStrokeJoinRound,
       preventCurveOverShooting: b.preventCurveOverShooting,
       preventCurveOvershootingThreshold: lerpDouble(
           a.preventCurveOvershootingThreshold,
@@ -437,6 +445,7 @@ class LineChartBarData with EquatableMixin {
     bool? preventCurveOverShooting,
     double? preventCurveOvershootingThreshold,
     bool? isStrokeCapRound,
+    bool? isStrokeJoinRound,
     BarAreaData? belowBarData,
     BarAreaData? aboveBarData,
     FlDotData? dotData,
@@ -459,6 +468,7 @@ class LineChartBarData with EquatableMixin {
       preventCurveOvershootingThreshold: preventCurveOvershootingThreshold ??
           this.preventCurveOvershootingThreshold,
       isStrokeCapRound: isStrokeCapRound ?? this.isStrokeCapRound,
+      isStrokeJoinRound: isStrokeJoinRound ?? this.isStrokeJoinRound,
       belowBarData: belowBarData ?? this.belowBarData,
       aboveBarData: aboveBarData ?? this.aboveBarData,
       dashArray: dashArray ?? this.dashArray,
@@ -483,6 +493,7 @@ class LineChartBarData with EquatableMixin {
         preventCurveOverShooting,
         preventCurveOvershootingThreshold,
         isStrokeCapRound,
+        isStrokeJoinRound,
         belowBarData,
         aboveBarData,
         dotData,

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -365,7 +365,7 @@ class LineChartBarData with EquatableMixin {
         shadow = shadow ?? const Shadow(color: Colors.transparent),
         isStepLineChart = isStepLineChart ?? false,
         lineChartStepData = lineChartStepData ?? LineChartStepData() {
-    FlSpot? _mostLeft, _mostTop, _mostRight, _mostBottom;
+    FlSpot? mostLeft, mostTop, mostRight, mostBottom;
 
     FlSpot? firstValidSpot;
     try {
@@ -379,26 +379,26 @@ class LineChartBarData with EquatableMixin {
         if (spot.isNull()) {
           continue;
         }
-        if (_mostLeft == null || spot.x < _mostLeft.x) {
-          _mostLeft = spot;
+        if (mostLeft == null || spot.x < mostLeft.x) {
+          mostLeft = spot;
         }
 
-        if (_mostRight == null || spot.x > _mostRight.x) {
-          _mostRight = spot;
+        if (mostRight == null || spot.x > mostRight.x) {
+          mostRight = spot;
         }
 
-        if (_mostTop == null || spot.y > _mostTop.y) {
-          _mostTop = spot;
+        if (mostTop == null || spot.y > mostTop.y) {
+          mostTop = spot;
         }
 
-        if (_mostBottom == null || spot.y < _mostBottom.y) {
-          _mostBottom = spot;
+        if (mostBottom == null || spot.y < mostBottom.y) {
+          mostBottom = spot;
         }
       }
-      mostLeftSpot = _mostLeft!;
-      mostTopSpot = _mostTop!;
-      mostRightSpot = _mostRight!;
-      mostBottomSpot = _mostBottom!;
+      mostLeftSpot = mostLeft!;
+      mostTopSpot = mostTop!;
+      mostRightSpot = mostRight!;
+      mostBottomSpot = mostBottom!;
     }
   }
 

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -795,6 +795,8 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
 
     _barPaint.strokeCap =
         barData.isStrokeCapRound ? StrokeCap.round : StrokeCap.butt;
+    _barPaint.strokeJoin =
+        barData.isStrokeJoinRound ? StrokeJoin.round : StrokeJoin.miter;
     _barPaint.color = barData.shadow.color;
     _barPaint.shader = null;
     _barPaint.strokeWidth = barData.barWidth;
@@ -827,6 +829,8 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
 
     _barPaint.strokeCap =
         barData.isStrokeCapRound ? StrokeCap.round : StrokeCap.butt;
+    _barPaint.strokeJoin =
+        barData.isStrokeJoinRound ? StrokeJoin.round : StrokeJoin.miter;
 
     final rectAroundTheLine = Rect.fromLTRB(
       getPixelX(barData.mostLeftSpot.x, viewSize, holder),

--- a/lib/src/chart/pie_chart/pie_chart.dart
+++ b/lib/src/chart/pie_chart/pie_chart.dart
@@ -39,7 +39,7 @@ class _PieChartState extends AnimatedWidgetBaseState<PieChart> {
   @override
   void initState() {
     /// Make sure that [_widgetsPositionHandler] is updated.
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         setState(() {});
       }

--- a/lib/src/chart/pie_chart/pie_chart.dart
+++ b/lib/src/chart/pie_chart/pie_chart.dart
@@ -86,10 +86,10 @@ class BadgeWidgetsDelegate extends MultiChildLayoutDelegate {
   @override
   void performLayout(Size size) {
     for (var index = 0; index < badgeWidgetsCount; index++) {
-      final _key = badgeWidgetsOffsets.keys.elementAt(index);
+      final key = badgeWidgetsOffsets.keys.elementAt(index);
 
-      final _size = layoutChild(
-        _key,
+      final finalSize = layoutChild(
+        key,
         BoxConstraints(
           maxWidth: size.width,
           maxHeight: size.height,
@@ -97,10 +97,10 @@ class BadgeWidgetsDelegate extends MultiChildLayoutDelegate {
       );
 
       positionChild(
-        _key,
+        key,
         Offset(
-          badgeWidgetsOffsets[_key]!.dx - (_size.width / 2),
-          badgeWidgetsOffsets[_key]!.dy - (_size.height / 2),
+          badgeWidgetsOffsets[key]!.dx - (finalSize.width / 2),
+          badgeWidgetsOffsets[key]!.dy - (finalSize.height / 2),
         ),
       );
     }

--- a/lib/src/chart/scatter_chart/scatter_chart.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart.dart
@@ -8,6 +8,10 @@ class ScatterChart extends ImplicitlyAnimatedWidget {
   /// Determines how the [ScatterChart] should be look like.
   final ScatterChartData data;
 
+  /// We pass this key to our renderers which are responsible to
+  /// render the chart itself (without anything around the chart).
+  final Key? chartRendererKey;
+
   /// [data] determines how the [ScatterChart] should be look like,
   /// when you make any change in the [ScatterChartData], it updates
   /// new values with animation, and duration is [swapAnimationDuration].
@@ -15,6 +19,7 @@ class ScatterChart extends ImplicitlyAnimatedWidget {
   /// which default is [Curves.linear].
   const ScatterChart(
     this.data, {
+    this.chartRendererKey,
     Key? key,
     Duration swapAnimationDuration = const Duration(milliseconds: 150),
     Curve swapAnimationCurve = Curves.linear,
@@ -49,6 +54,7 @@ class _ScatterChartState extends AnimatedWidgetBaseState<ScatterChart> {
         data:
             _withTouchedIndicators(_scatterChartDataTween!.evaluate(animation)),
         targetData: _withTouchedIndicators(showingData),
+        key: widget.chartRendererKey,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A powerful Flutter chart library, currently supporting Line Chart, Bar Chart and Pie Chart.
-version: 0.50.3
+version: 0.50.4
 homepage: https://github.com/imaNNeoFighT/fl_chart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A powerful Flutter chart library, currently supporting Line Chart, Bar Chart and Pie Chart.
-version: 0.50.1
+version: 0.50.3
 homepage: https://github.com/imaNNeoFighT/fl_chart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   mockito: ^5.1.0
   build_runner: ^2.1.7
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
   vector_math: ^2.1.1 #Added to use in some generated codes of mockito
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A powerful Flutter chart library, currently supporting Line Chart, Bar Chart and Pie Chart.
-version: 0.50.4
+version: 0.50.5
 homepage: https://github.com/imaNNeoFighT/fl_chart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A powerful Flutter chart library, currently supporting Line Chart, Bar Chart and Pie Chart.
-version: 0.50.2
+version: 0.50.1
 homepage: https://github.com/imaNNeoFighT/fl_chart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A powerful Flutter chart library, currently supporting Line Chart, Bar Chart and Pie Chart.
-version: 0.50.1
+version: 0.50.2
 homepage: https://github.com/imaNNeoFighT/fl_chart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
 
 dev_dependencies:
   mockito: ^5.1.0
-  build_runner: ^2.1.7
+  build_runner: ^2.1.10
   flutter_lints: ^2.0.1
-  vector_math: ^2.1.1 #Added to use in some generated codes of mockito
+  vector_math: ^2.1.2 #Added to use in some generated codes of mockito
   flutter_test:
     sdk: flutter
 

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -52,6 +52,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |preventCurveOverShooting|prevent overshooting when draw curve line on linear sequence spots, check this [issue](https://github.com/imaNNeoFighT/fl_chart/issues/25)| false|
 |preventCurveOvershootingThreshold|threshold for applying prevent overshooting algorithm | 10.0|
 |isStrokeCapRound| determines whether start and end of the bar line is Qubic or Round | false|
+|isStrokeJoinRound| determines whether stroke joins have a round shape or a sharp edge | false|
 |belowBarData| check the [BarAreaData](#BarAreaData) |BarAreaData|
 |aboveBarData| check the [BarAreaData](#BarAreaData) |BarAreaData|
 |dotData| check the [FlDotData](#FlDotData) | FlDotData()|

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -41,34 +41,34 @@ void main() {
       final barChartPainter = BarChartPainter();
       final holder = PaintHolder<BarChartData>(data, data, 1.0);
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenAnswer((realInvocation) => textStyle1);
-      when(_mockUtils.calculateRotationOffset(any, any))
+      when(mockUtils.calculateRotationOffset(any, any))
           .thenAnswer((realInvocation) => Offset.zero);
-      when(_mockUtils.convertRadiusToSigma(any))
+      when(mockUtils.convertRadiusToSigma(any))
           .thenAnswer((realInvocation) => 4.0);
-      when(_mockUtils.getEfficientInterval(any, any))
+      when(mockUtils.getEfficientInterval(any, any))
           .thenAnswer((realInvocation) => 1.0);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 1.0);
-      when(_mockUtils.normalizeBorderRadius(any, any))
+      when(mockUtils.normalizeBorderRadius(any, any))
           .thenAnswer((realInvocation) => BorderRadius.zero);
-      when(_mockUtils.normalizeBorderSide(any, any)).thenAnswer(
+      when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
           (realInvocation) => const BorderSide(color: MockData.color0));
 
-      final _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       barChartPainter.paint(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawLine(any, any, any)).called(4);
+      verify(mockCanvasWrapper.drawLine(any, any, any)).called(4);
       Utils.changeInstance(utilsMainInstance);
     });
   });
@@ -322,16 +322,16 @@ void main() {
       final BarChartPainter barChartPainter = BarChartPainter();
       final holder = PaintHolder<BarChartData>(data, data, 1.0);
 
-      final MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final groupsX = data.calculateGroupsX(viewSize.width);
       final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
           viewSize, groupsX, barGroups);
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawRRect(captureAny, captureAny))
+      when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
           .thenAnswer((inv) {
         final rRect = inv.positionalArguments[0] as RRect;
         final paint = inv.positionalArguments[1] as Paint;
@@ -350,7 +350,7 @@ void main() {
         });
       });
 
-      barChartPainter.drawBars(_mockCanvasWrapper, barGroupsPosition, holder);
+      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
       expect(results.length, 11);
 
       expect(
@@ -578,16 +578,16 @@ void main() {
       final BarChartPainter barChartPainter = BarChartPainter();
       final holder = PaintHolder<BarChartData>(data, data, 1.0);
 
-      final MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final groupsX = data.calculateGroupsX(viewSize.width);
       final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
           viewSize, groupsX, barGroups);
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawRRect(captureAny, captureAny))
+      when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
           .thenAnswer((inv) {
         final rrect = inv.positionalArguments[0] as RRect;
         final paint = inv.positionalArguments[1] as Paint;
@@ -606,7 +606,7 @@ void main() {
         });
       });
 
-      barChartPainter.drawBars(_mockCanvasWrapper, barGroupsPosition, holder);
+      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
       expect(results.length, 6);
 
       expect(
@@ -698,22 +698,20 @@ void main() {
 
   group('drawTouchTooltip()', () {
     test('test 1', () {
-      final MockUtils _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle1);
-      when(_mockUtils.getEfficientInterval(any, any)).thenReturn(11);
-      when(_mockUtils.normalizeBorderRadius(any, any))
+      final MockUtils mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle1);
+      when(mockUtils.getEfficientInterval(any, any)).thenReturn(11);
+      when(mockUtils.normalizeBorderRadius(any, any))
           .thenReturn(BorderRadius.zero);
-      when(_mockUtils.normalizeBorderSide(any, any))
-          .thenReturn(BorderSide.none);
-      when(_mockUtils.calculateRotationOffset(any, any))
-          .thenReturn(Offset.zero);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.normalizeBorderSide(any, any)).thenReturn(BorderSide.none);
+      when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenReturn(0.0);
-      when(_mockUtils.formatNumber(captureAny)).thenAnswer((inv) {
+      when(mockUtils.formatNumber(captureAny)).thenAnswer((inv) {
         final value = inv.positionalArguments[0] as double;
         return '${value.toInt()}';
       });
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
       const viewSize = Size(200, 100);
 
@@ -794,18 +792,18 @@ void main() {
       final BarChartPainter barChartPainter = BarChartPainter();
       final holder = PaintHolder<BarChartData>(data, data, 1.0);
 
-      final MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final MockBuildContext _mockBuildContext = MockBuildContext();
+      final MockBuildContext mockBuildContext = MockBuildContext();
 
       final groupsX = data.calculateGroupsX(viewSize.width);
       final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
           viewSize, groupsX, barGroups);
 
       final angles = <double>[];
-      when(_mockCanvasWrapper.drawRotated(
+      when(mockCanvasWrapper.drawRotated(
         size: anyNamed('size'),
         rotationOffset: anyNamed('rotationOffset'),
         drawOffset: anyNamed('drawOffset'),
@@ -818,8 +816,8 @@ void main() {
       });
 
       barChartPainter.drawTouchTooltip(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         barGroupsPosition,
         tooltipData,
         barGroups[0],
@@ -829,7 +827,7 @@ void main() {
         holder,
       );
       final result1 =
-          verify(_mockCanvasWrapper.drawRRect(captureAny, captureAny));
+          verify(mockCanvasWrapper.drawRRect(captureAny, captureAny));
       result1.called(1);
       final rrect = result1.captured[0] as RRect;
       expect(rrect.blRadius, const Radius.circular(8.0));
@@ -846,7 +844,7 @@ void main() {
       expect(angles[0], 12);
 
       final result2 =
-          verify(_mockCanvasWrapper.drawText(captureAny, captureAny));
+          verify(mockCanvasWrapper.drawText(captureAny, captureAny));
       result2.called(1);
       final textPainter = result2.captured[0] as TextPainter;
       expect((textPainter.text as TextSpan).text, 'helllo1');
@@ -863,22 +861,20 @@ void main() {
     });
 
     test('test 2', () {
-      final MockUtils _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle1);
-      when(_mockUtils.getEfficientInterval(any, any)).thenReturn(11);
-      when(_mockUtils.normalizeBorderRadius(any, any))
+      final MockUtils mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle1);
+      when(mockUtils.getEfficientInterval(any, any)).thenReturn(11);
+      when(mockUtils.normalizeBorderRadius(any, any))
           .thenReturn(BorderRadius.zero);
-      when(_mockUtils.normalizeBorderSide(any, any))
-          .thenReturn(BorderSide.none);
-      when(_mockUtils.calculateRotationOffset(any, any))
-          .thenReturn(Offset.zero);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.normalizeBorderSide(any, any)).thenReturn(BorderSide.none);
+      when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenReturn(0.0);
-      when(_mockUtils.formatNumber(captureAny)).thenAnswer((inv) {
+      when(mockUtils.formatNumber(captureAny)).thenAnswer((inv) {
         final value = inv.positionalArguments[0] as double;
         return '${value.toInt()}';
       });
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
       const viewSize = Size(200, 100);
 
@@ -960,18 +956,18 @@ void main() {
       final BarChartPainter barChartPainter = BarChartPainter();
       final holder = PaintHolder<BarChartData>(data, data, 1.0);
 
-      final MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final MockBuildContext _mockBuildContext = MockBuildContext();
+      final MockBuildContext mockBuildContext = MockBuildContext();
 
       final groupsX = data.calculateGroupsX(viewSize.width);
       final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
           viewSize, groupsX, barGroups);
 
       final angles = <double>[];
-      when(_mockCanvasWrapper.drawRotated(
+      when(mockCanvasWrapper.drawRotated(
         size: anyNamed('size'),
         rotationOffset: anyNamed('rotationOffset'),
         drawOffset: anyNamed('drawOffset'),
@@ -984,8 +980,8 @@ void main() {
       });
 
       barChartPainter.drawTouchTooltip(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         barGroupsPosition,
         tooltipData,
         barGroups[0],
@@ -995,7 +991,7 @@ void main() {
         holder,
       );
       final result1 =
-          verify(_mockCanvasWrapper.drawRRect(captureAny, captureAny));
+          verify(mockCanvasWrapper.drawRRect(captureAny, captureAny));
       result1.called(1);
       final rrect = result1.captured[0] as RRect;
       expect(rrect.blRadius, const Radius.circular(8.0));
@@ -1012,7 +1008,7 @@ void main() {
       expect(angles[0], 12);
 
       final result2 =
-          verify(_mockCanvasWrapper.drawText(captureAny, captureAny));
+          verify(mockCanvasWrapper.drawText(captureAny, captureAny));
       result2.called(1);
       final textPainter = result2.captured[0] as TextPainter;
       expect((textPainter.text as TextSpan).text, 'helllo1');
@@ -1029,22 +1025,20 @@ void main() {
     });
 
     test('test 3', () {
-      final MockUtils _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle1);
-      when(_mockUtils.getEfficientInterval(any, any)).thenReturn(11);
-      when(_mockUtils.normalizeBorderRadius(any, any))
+      final MockUtils mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle1);
+      when(mockUtils.getEfficientInterval(any, any)).thenReturn(11);
+      when(mockUtils.normalizeBorderRadius(any, any))
           .thenReturn(BorderRadius.zero);
-      when(_mockUtils.normalizeBorderSide(any, any))
-          .thenReturn(BorderSide.none);
-      when(_mockUtils.calculateRotationOffset(any, any))
-          .thenReturn(Offset.zero);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.normalizeBorderSide(any, any)).thenReturn(BorderSide.none);
+      when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenReturn(0.0);
-      when(_mockUtils.formatNumber(captureAny)).thenAnswer((inv) {
+      when(mockUtils.formatNumber(captureAny)).thenAnswer((inv) {
         final value = inv.positionalArguments[0] as double;
         return '${value.toInt()}';
       });
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
       const viewSize = Size(200, 100);
 
@@ -1104,18 +1098,18 @@ void main() {
       final BarChartPainter barChartPainter = BarChartPainter();
       final holder = PaintHolder<BarChartData>(data, data, 1.0);
 
-      final MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final MockBuildContext _mockBuildContext = MockBuildContext();
+      final MockBuildContext mockBuildContext = MockBuildContext();
 
       final groupsX = data.calculateGroupsX(viewSize.width);
       final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
           viewSize, groupsX, barGroups);
 
       final angles = <double>[];
-      when(_mockCanvasWrapper.drawRotated(
+      when(mockCanvasWrapper.drawRotated(
         size: anyNamed('size'),
         rotationOffset: anyNamed('rotationOffset'),
         drawOffset: anyNamed('drawOffset'),
@@ -1128,8 +1122,8 @@ void main() {
       });
 
       barChartPainter.drawTouchTooltip(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         barGroupsPosition,
         tooltipData,
         barGroups[0],
@@ -1139,7 +1133,7 @@ void main() {
         holder,
       );
       final result1 =
-          verify(_mockCanvasWrapper.drawRRect(captureAny, captureAny));
+          verify(mockCanvasWrapper.drawRRect(captureAny, captureAny));
       result1.called(1);
       final rrect = result1.captured[0] as RRect;
       expect(rrect.blRadius, const Radius.circular(8.0));
@@ -1156,7 +1150,7 @@ void main() {
       expect(angles[0], 12);
 
       final result2 =
-          verify(_mockCanvasWrapper.drawText(captureAny, captureAny));
+          verify(mockCanvasWrapper.drawText(captureAny, captureAny));
       result2.called(1);
 
       final drawOffset = result2.captured[1] as Offset;
@@ -1207,12 +1201,12 @@ void main() {
       final BarChartPainter barChartPainter = BarChartPainter();
       final holder = PaintHolder<BarChartData>(data, data, 1.0);
 
-      final MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawRRect(
+      when(mockCanvasWrapper.drawRRect(
         captureAny,
         captureAny,
       )).thenAnswer((inv) {
@@ -1226,7 +1220,7 @@ void main() {
       });
 
       barChartPainter.drawStackItemBorderStroke(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         rodStackItems[0],
         0,
         3,
@@ -1238,7 +1232,7 @@ void main() {
       );
 
       barChartPainter.drawStackItemBorderStroke(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         rodStackItems[1],
         1,
         3,
@@ -1250,7 +1244,7 @@ void main() {
       );
 
       barChartPainter.drawStackItemBorderStroke(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         rodStackItems[2],
         2,
         3,

--- a/test/chart/bar_chart/bar_chart_painter_test.mocks.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.mocks.dart
@@ -390,6 +390,10 @@ class MockBuildContext extends _i1.Mock implements _i3.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i3.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i3.DiagnosticsNode describeElement(String? name,
           {_i4.DiagnosticsTreeStyle? style =
               _i4.DiagnosticsTreeStyle.errorProperty}) =>

--- a/test/chart/bar_chart/bar_chart_renderer_test.dart
+++ b/test/chart/bar_chart/bar_chart_renderer_test.dart
@@ -35,22 +35,21 @@ void main() {
 
     const textScale = 4.0;
 
-    MockBuildContext _mockBuildContext = MockBuildContext();
+    MockBuildContext mockBuildContext = MockBuildContext();
     RenderBarChart renderBarChart = RenderBarChart(
-      _mockBuildContext,
+      mockBuildContext,
       data,
       targetData,
       textScale,
     );
 
-    MockBarChartPainter _mockPainter = MockBarChartPainter();
-    MockPaintingContext _mockPaintingContext = MockPaintingContext();
-    MockCanvas _mockCanvas = MockCanvas();
-    Size _mockSize = const Size(44, 44);
-    when(_mockPaintingContext.canvas)
-        .thenAnswer((realInvocation) => _mockCanvas);
-    renderBarChart.mockTestSize = _mockSize;
-    renderBarChart.painter = _mockPainter;
+    MockBarChartPainter mockPainter = MockBarChartPainter();
+    MockPaintingContext mockPaintingContext = MockPaintingContext();
+    MockCanvas mockCanvas = MockCanvas();
+    Size mockSize = const Size(44, 44);
+    when(mockPaintingContext.canvas).thenAnswer((realInvocation) => mockCanvas);
+    renderBarChart.mockTestSize = mockSize;
+    renderBarChart.painter = mockPainter;
 
     test('test 1 correct data set', () {
       expect(renderBarChart.data == data, true);
@@ -63,27 +62,27 @@ void main() {
     });
 
     test('test 2 check paint function', () {
-      renderBarChart.paint(_mockPaintingContext, const Offset(10, 10));
-      verify(_mockCanvas.save()).called(1);
-      verify(_mockCanvas.translate(10, 10)).called(1);
-      final result = verify(_mockPainter.paint(any, captureAny, captureAny));
+      renderBarChart.paint(mockPaintingContext, const Offset(10, 10));
+      verify(mockCanvas.save()).called(1);
+      verify(mockCanvas.translate(10, 10)).called(1);
+      final result = verify(mockPainter.paint(any, captureAny, captureAny));
       expect(result.callCount, 1);
 
       final canvasWrapper = result.captured[0] as CanvasWrapper;
       expect(canvasWrapper.size, const Size(44, 44));
-      expect(canvasWrapper.canvas, _mockCanvas);
+      expect(canvasWrapper.canvas, mockCanvas);
 
       final paintHolder = result.captured[1] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);
       expect(paintHolder.textScale, textScale);
 
-      verify(_mockCanvas.restore()).called(1);
+      verify(mockCanvas.restore()).called(1);
     });
 
     test('test 3 check getResponseAtLocation function', () {
       List<Map<String, dynamic>> results = [];
-      when(_mockPainter.handleTouch(captureAny, captureAny, captureAny))
+      when(mockPainter.handleTouch(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
           'local_position': inv.positionalArguments[0] as Offset,
@@ -96,7 +95,7 @@ void main() {
           renderBarChart.getResponseAtLocation(MockData.offset1);
       expect(touchResponse.spot, MockData.barTouchedSpot);
       expect(results[0]['local_position'] as Offset, MockData.offset1);
-      expect(results[0]['size'] as Size, _mockSize);
+      expect(results[0]['size'] as Size, mockSize);
       final paintHolder = results[0]['paint_holder'] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);

--- a/test/chart/bar_chart/bar_chart_renderer_test.mocks.dart
+++ b/test/chart/bar_chart/bar_chart_renderer_test.mocks.dart
@@ -5,15 +5,16 @@
 import 'dart:typed_data' as _i7;
 import 'dart:ui' as _i2;
 
-import 'package:fl_chart/fl_chart.dart' as _i12;
-import 'package:fl_chart/src/chart/bar_chart/bar_chart_painter.dart' as _i9;
+import 'package:fl_chart/fl_chart.dart' as _i13;
+import 'package:fl_chart/src/chart/bar_chart/bar_chart_painter.dart' as _i10;
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart'
-    as _i11;
-import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i10;
+    as _i12;
+import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i11;
 import 'package:flutter/foundation.dart' as _i5;
 import 'package:flutter/material.dart' as _i6;
 import 'package:flutter/rendering.dart' as _i3;
 import 'package:flutter/src/rendering/layer.dart' as _i4;
+import 'package:flutter/src/widgets/notification_listener.dart' as _i9;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:vector_math/vector_math_64.dart' as _i8;
 
@@ -435,6 +436,10 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i9.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i5.DiagnosticsNode describeElement(String? name,
           {_i5.DiagnosticsTreeStyle? style =
               _i5.DiagnosticsTreeStyle.errorProperty}) =>
@@ -464,30 +469,30 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
 /// A class which mocks [BarChartPainter].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBarChartPainter extends _i1.Mock implements _i9.BarChartPainter {
+class MockBarChartPainter extends _i1.Mock implements _i10.BarChartPainter {
   MockBarChartPainter() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void paint(_i6.BuildContext? context, _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+  void paint(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#paint, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  List<_i9.GroupBarsPosition> calculateGroupAndBarsPosition(_i2.Size? viewSize,
-          List<double>? groupsX, List<_i12.BarChartGroupData>? barGroups) =>
+  List<_i10.GroupBarsPosition> calculateGroupAndBarsPosition(_i2.Size? viewSize,
+          List<double>? groupsX, List<_i13.BarChartGroupData>? barGroups) =>
       (super.noSuchMethod(
               Invocation.method(#calculateGroupAndBarsPosition,
                   [viewSize, groupsX, barGroups]),
-              returnValue: <_i9.GroupBarsPosition>[])
-          as List<_i9.GroupBarsPosition>);
+              returnValue: <_i10.GroupBarsPosition>[])
+          as List<_i10.GroupBarsPosition>);
   @override
   void drawBars(
-          _i10.CanvasWrapper? canvasWrapper,
-          List<_i9.GroupBarsPosition>? groupBarsPosition,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          List<_i10.GroupBarsPosition>? groupBarsPosition,
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(
               #drawBars, [canvasWrapper, groupBarsPosition, holder]),
@@ -495,14 +500,14 @@ class MockBarChartPainter extends _i1.Mock implements _i9.BarChartPainter {
   @override
   void drawTouchTooltip(
           _i6.BuildContext? context,
-          _i10.CanvasWrapper? canvasWrapper,
-          List<_i9.GroupBarsPosition>? groupPositions,
-          _i12.BarTouchTooltipData? tooltipData,
-          _i12.BarChartGroupData? showOnBarGroup,
+          _i11.CanvasWrapper? canvasWrapper,
+          List<_i10.GroupBarsPosition>? groupPositions,
+          _i13.BarTouchTooltipData? tooltipData,
+          _i13.BarChartGroupData? showOnBarGroup,
           int? barGroupIndex,
-          _i12.BarChartRodData? showOnRodData,
+          _i13.BarChartRodData? showOnRodData,
           int? barRodIndex,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawTouchTooltip, [
             context,
@@ -518,14 +523,14 @@ class MockBarChartPainter extends _i1.Mock implements _i9.BarChartPainter {
           returnValueForMissingStub: null);
   @override
   void drawStackItemBorderStroke(
-          _i10.CanvasWrapper? canvasWrapper,
-          _i12.BarChartRodStackItem? stackItem,
+          _i11.CanvasWrapper? canvasWrapper,
+          _i13.BarChartRodStackItem? stackItem,
           int? index,
           int? rodStacksSize,
           double? barThickSize,
           _i2.RRect? barRRect,
           _i2.Size? drawSize,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawStackItemBorderStroke, [
             canvasWrapper,
@@ -539,37 +544,37 @@ class MockBarChartPainter extends _i1.Mock implements _i9.BarChartPainter {
           ]),
           returnValueForMissingStub: null);
   @override
-  _i12.BarTouchedSpot? handleTouch(_i2.Offset? localPosition,
-          _i2.Size? viewSize, _i11.PaintHolder<_i12.BarChartData>? holder) =>
+  _i13.BarTouchedSpot? handleTouch(_i2.Offset? localPosition,
+          _i2.Size? viewSize, _i12.PaintHolder<_i13.BarChartData>? holder) =>
       (super.noSuchMethod(Invocation.method(
               #handleTouch, [localPosition, viewSize, holder]))
-          as _i12.BarTouchedSpot?);
+          as _i13.BarTouchedSpot?);
   @override
-  void drawGrid(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+  void drawGrid(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       super.noSuchMethod(Invocation.method(#drawGrid, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawBackground(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+  void drawBackground(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawBackground, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawRangeAnnotation(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+  void drawRangeAnnotation(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawRangeAnnotation, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
   double getPixelX(double? spotX, _i2.Size? viewSize,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#getPixelX, [spotX, viewSize, holder]),
           returnValue: 0.0) as double);
   @override
   double getPixelY(double? spotY, _i2.Size? viewSize,
-          _i11.PaintHolder<_i12.BarChartData>? holder) =>
+          _i12.PaintHolder<_i13.BarChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#getPixelY, [spotY, viewSize, holder]),
           returnValue: 0.0) as double);

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -20,15 +20,17 @@ void main() {
     test('test 1', () {
       const viewSize = Size(400, 400);
 
-      final bar1 = LineChartBarData(
-        spots: const [
-          FlSpot(0, 4),
-          FlSpot(1, 3),
-          FlSpot(2, 2),
-          FlSpot(3, 1),
-          FlSpot(4, 0),
-        ],
-      );
+      final bar1 = LineChartBarData(spots: const [
+        FlSpot(0, 4),
+        FlSpot(1, 3),
+        FlSpot(2, 2),
+        FlSpot(3, 1),
+        FlSpot(4, 0),
+      ], showingIndicators: [
+        0,
+        2,
+        3,
+      ]);
       final bar2 = LineChartBarData(
         spots: const [
           FlSpot(0, 5),
@@ -39,31 +41,45 @@ void main() {
         ],
       );
       final LineChartData data = LineChartData(
-          lineBarsData: [
-            bar1,
-            bar2,
+        lineBarsData: [
+          bar1,
+          bar2,
+        ],
+        clipData: FlClipData.all(),
+        extraLinesData: ExtraLinesData(
+          horizontalLines: [
+            HorizontalLine(y: 1),
           ],
-          clipData: FlClipData.all(),
-          extraLinesData: ExtraLinesData(
-            horizontalLines: [
-              HorizontalLine(y: 1),
-            ],
-            verticalLines: [
-              VerticalLine(x: 4),
-            ],
-          ),
-          betweenBarsData: [
-            BetweenBarsData(fromIndex: 0, toIndex: 1),
+          verticalLines: [
+            VerticalLine(x: 4),
           ],
-          showingTooltipIndicators: [
-            ShowingTooltipIndicators([
-              LineBarSpot(bar1, 0, bar1.spots.first),
-              LineBarSpot(bar2, 1, bar2.spots.first),
-            ])
-          ],
-          lineTouchData: LineTouchData(
-            enabled: true,
-          ));
+        ),
+        betweenBarsData: [
+          BetweenBarsData(fromIndex: 0, toIndex: 1),
+        ],
+        showingTooltipIndicators: [
+          ShowingTooltipIndicators([
+            LineBarSpot(bar1, 0, bar1.spots.first),
+            LineBarSpot(bar2, 1, bar2.spots.first),
+          ])
+        ],
+        lineTouchData: LineTouchData(
+          enabled: true,
+          getTouchedSpotIndicator:
+              (LineChartBarData barData, List<int> spotIndexes) {
+            return spotIndexes.asMap().entries.map((entry) {
+              final i = entry.key;
+              if (i == 0) {
+                return null;
+              }
+              return TouchedSpotIndicatorData(
+                FlLine(color: MockData.color0),
+                FlDotData(show: true),
+              );
+            }).toList();
+          },
+        ),
+      );
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
@@ -93,8 +109,103 @@ void main() {
 
       verify(_mockCanvasWrapper.clipRect(any)).called(1);
       verify(_mockCanvasWrapper.drawLine(any, any, any)).called(4);
-      verify(_mockCanvasWrapper.drawDot(any, any, any)).called(10);
+      verify(_mockCanvasWrapper.drawDot(any, any, any)).called(12);
       verify(_mockCanvasWrapper.drawPath(any, any)).called(3);
+    });
+    test('test 2', () {
+      const viewSize = Size(400, 400);
+
+      final bar1 = LineChartBarData(
+        spots: const [
+          FlSpot(0, 4),
+          FlSpot(1, 3),
+          FlSpot(2, 2),
+          FlSpot(3, 1),
+          FlSpot(4, 0),
+        ],
+      );
+      final bar2 = LineChartBarData(
+        spots: const [
+          FlSpot(0, 2),
+          FlSpot(1, 5),
+          FlSpot(2, 1),
+          FlSpot(3, 2),
+          FlSpot(4, 3),
+        ],
+      );
+      final LineChartData data = LineChartData(
+        lineBarsData: [
+          bar1,
+          bar2,
+        ],
+        clipData: FlClipData.all(),
+        lineTouchData: LineTouchData(
+          enabled: true,
+          getTouchedSpotIndicator:
+              (LineChartBarData barData, List<int> spotIndexes) {
+            return List.generate(
+              spotIndexes.length + 1,
+              (index) {
+                return TouchedSpotIndicatorData(
+                  FlLine(color: MockData.color0),
+                  FlDotData(show: true),
+                );
+              },
+            ).toList();
+          },
+        ),
+        extraLinesData: ExtraLinesData(
+          horizontalLines: [
+            HorizontalLine(y: 1),
+          ],
+          verticalLines: [
+            VerticalLine(x: 4),
+          ],
+          extraLinesOnTop: false,
+        ),
+        showingTooltipIndicators: [
+          ShowingTooltipIndicators([
+            LineBarSpot(bar1, 0, bar1.spots[0]),
+            LineBarSpot(bar1, 0, bar1.spots[2]),
+            LineBarSpot(bar2, 1, bar1.spots[2]),
+            LineBarSpot(bar2, 1, bar1.spots[3]),
+            LineBarSpot(bar2, 1, bar1.spots[4]),
+          ])
+        ],
+      );
+
+      final LineChartPainter lineChartPainter = LineChartPainter();
+      final holder = PaintHolder<LineChartData>(data, data, 1.0);
+
+      MockUtils _mockUtils = MockUtils();
+      Utils.changeInstance(_mockUtils);
+      when(_mockUtils.getThemeAwareTextStyle(any, any))
+          .thenAnswer((realInvocation) => textStyle1);
+      when(_mockUtils.calculateRotationOffset(any, any))
+          .thenAnswer((realInvocation) => Offset.zero);
+      when(_mockUtils.convertRadiusToSigma(any))
+          .thenAnswer((realInvocation) => 4.0);
+      when(_mockUtils.getEfficientInterval(any, any))
+          .thenAnswer((realInvocation) => 1.0);
+      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+          .thenAnswer((realInvocation) => 1.0);
+
+      final _mockBuildContext = MockBuildContext();
+      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
+      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      Exception? exception;
+      try {
+        lineChartPainter.paint(
+          _mockBuildContext,
+          _mockCanvasWrapper,
+          holder,
+        );
+      } on Exception catch (e) {
+        exception = e;
+      }
+      expect(exception != null, true);
     });
   });
 
@@ -553,6 +664,41 @@ void main() {
   });
 
   group('drawTouchedSpotsIndicator()', () {
+    List<LineIndexDrawingInfo> getDrawingInfo(LineChartData data) {
+      List<LineIndexDrawingInfo> lineIndexDrawingInfo = [];
+
+      /// draw each line independently on the chart
+      for (var i = 0; i < data.lineBarsData.length; i++) {
+        final barData = data.lineBarsData[i];
+
+        if (!barData.show) {
+          continue;
+        }
+
+        final indicatorsData = data.lineTouchData
+            .getTouchedSpotIndicator(barData, barData.showingIndicators);
+
+        if (indicatorsData.length != barData.showingIndicators.length) {
+          throw Exception(
+              'indicatorsData and touchedSpotOffsets size should be same');
+        }
+
+        for (var j = 0; j < barData.showingIndicators.length; j++) {
+          final indicatorData = indicatorsData[j];
+          final index = barData.showingIndicators[j];
+          final spot = barData.spots[index];
+
+          if (indicatorData == null) {
+            continue;
+          }
+          lineIndexDrawingInfo.add(
+            LineIndexDrawingInfo(barData, i, spot, index, indicatorData),
+          );
+        }
+      }
+      return lineIndexDrawingInfo;
+    }
+
     test('test 1', () {
       const viewSize = Size(400, 400);
 
@@ -575,7 +721,7 @@ void main() {
 
       lineChartPainter.drawTouchedSpotsIndicator(
         _mockCanvasWrapper,
-        lineChartBarData,
+        getDrawingInfo(data),
         holder,
       );
 
@@ -635,17 +781,17 @@ void main() {
 
       lineChartPainter.drawTouchedSpotsIndicator(
         _mockCanvasWrapper,
-        lineChartBarData,
+        getDrawingInfo(data),
         holder,
       );
 
       expect(results.length, 2);
 
-      expect(results[0]['paint_color'], const Color(0xFF00FF00));
-      expect(results[0]['paint_stroke_width'], 8.0);
+      expect(results[0]['paint_color'], const Color(0xFF0000FF));
+      expect(results[0]['paint_stroke_width'], 12);
 
-      expect(results[1]['paint_color'], const Color(0xFF0000FF));
-      expect(results[1]['paint_stroke_width'], 12);
+      expect(results[1]['paint_color'], const Color(0xFF00FF00));
+      expect(results[1]['paint_stroke_width'], 8.0);
     });
 
     test('test 3', () {
@@ -700,17 +846,17 @@ void main() {
 
       lineChartPainter.drawTouchedSpotsIndicator(
         _mockCanvasWrapper,
-        lineChartBarData,
+        getDrawingInfo(data),
         holder,
       );
 
       expect(results.length, 2);
 
-      expect(results[0]['paint_color'], const Color(0xFF00FF00));
-      expect(results[0]['paint_stroke_width'], 8.0);
+      expect(results[0]['paint_color'], const Color(0xFF0000FF));
+      expect(results[0]['paint_stroke_width'], 12);
 
-      expect(results[1]['paint_color'], const Color(0xFF0000FF));
-      expect(results[1]['paint_stroke_width'], 12);
+      expect(results[1]['paint_color'], const Color(0xFF00FF00));
+      expect(results[1]['paint_stroke_width'], 8.0);
 
       verify(_mockCanvasWrapper.drawDot(any, any, any)).called(2);
     });

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -84,33 +84,33 @@ void main() {
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenAnswer((realInvocation) => textStyle1);
-      when(_mockUtils.calculateRotationOffset(any, any))
+      when(mockUtils.calculateRotationOffset(any, any))
           .thenAnswer((realInvocation) => Offset.zero);
-      when(_mockUtils.convertRadiusToSigma(any))
+      when(mockUtils.convertRadiusToSigma(any))
           .thenAnswer((realInvocation) => 4.0);
-      when(_mockUtils.getEfficientInterval(any, any))
+      when(mockUtils.getEfficientInterval(any, any))
           .thenAnswer((realInvocation) => 1.0);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 1.0);
 
-      final _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       lineChartPainter.paint(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verify(_mockCanvasWrapper.clipRect(any)).called(1);
-      verify(_mockCanvasWrapper.drawLine(any, any, any)).called(4);
-      verify(_mockCanvasWrapper.drawDot(any, any, any)).called(12);
-      verify(_mockCanvasWrapper.drawPath(any, any)).called(3);
+      verify(mockCanvasWrapper.clipRect(any)).called(1);
+      verify(mockCanvasWrapper.drawLine(any, any, any)).called(4);
+      verify(mockCanvasWrapper.drawDot(any, any, any)).called(12);
+      verify(mockCanvasWrapper.drawPath(any, any)).called(3);
     });
     test('test 2', () {
       const viewSize = Size(400, 400);
@@ -177,29 +177,29 @@ void main() {
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenAnswer((realInvocation) => textStyle1);
-      when(_mockUtils.calculateRotationOffset(any, any))
+      when(mockUtils.calculateRotationOffset(any, any))
           .thenAnswer((realInvocation) => Offset.zero);
-      when(_mockUtils.convertRadiusToSigma(any))
+      when(mockUtils.convertRadiusToSigma(any))
           .thenAnswer((realInvocation) => 4.0);
-      when(_mockUtils.getEfficientInterval(any, any))
+      when(mockUtils.getEfficientInterval(any, any))
           .thenAnswer((realInvocation) => 1.0);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 1.0);
 
-      final _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       Exception? exception;
       try {
         lineChartPainter.paint(
-          _mockBuildContext,
-          _mockCanvasWrapper,
+          mockBuildContext,
+          mockCanvasWrapper,
           holder,
         );
       } on Exception catch (e) {
@@ -224,15 +224,15 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       lineChartPainter.clipToBorder(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         holder,
       );
 
-      final verifyResult = verify(_mockCanvasWrapper.clipRect(captureAny));
+      final verifyResult = verify(mockCanvasWrapper.clipRect(captureAny));
       final Rect rect = verifyResult.captured.single;
       verifyResult.called(1);
       expect(rect.left, 0);
@@ -267,15 +267,15 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       lineChartPainter.clipToBorder(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         holder,
       );
 
-      final verifyResult = verify(_mockCanvasWrapper.clipRect(captureAny));
+      final verifyResult = verify(mockCanvasWrapper.clipRect(captureAny));
       final Rect rect = verifyResult.captured.single;
       verifyResult.called(1);
       expect(rect.left, 4);
@@ -313,15 +313,15 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       lineChartPainter.clipToBorder(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         holder,
       );
 
-      final verifyResult = verify(_mockCanvasWrapper.clipRect(captureAny));
+      final verifyResult = verify(mockCanvasWrapper.clipRect(captureAny));
       final Rect rect = verifyResult.captured.single;
       verifyResult.called(1);
       expect(rect.left, 4);
@@ -349,17 +349,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawBarLine(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         barData,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawPath(any, any)).called(1);
+      verify(mockCanvasWrapper.drawPath(any, any)).called(1);
     });
 
     test('test 2', () {
@@ -380,17 +380,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawBarLine(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         barData,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawPath(any, any)).called(2);
+      verify(mockCanvasWrapper.drawPath(any, any)).called(2);
     });
 
     test('test 3', () {
@@ -412,18 +412,18 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawBarLine(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         barData,
         holder,
       );
 
       final verificationResult =
-          verify(_mockCanvasWrapper.drawPath(any, captureAny));
+          verify(mockCanvasWrapper.drawPath(any, captureAny));
       final paint = verificationResult.captured.single as Paint;
       verificationResult.called(1);
       expect(paint.color.value,
@@ -473,21 +473,21 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawBetweenBarsArea(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         data,
         betweenBarData,
         holder,
       );
 
       final verifyResult = verifyInOrder([
-        _mockCanvasWrapper.saveLayer(const Rect.fromLTWH(0, 0, 400, 400), any),
-        _mockCanvasWrapper.drawPath(any, captureAny),
-        _mockCanvasWrapper.restore(),
+        mockCanvasWrapper.saveLayer(const Rect.fromLTWH(0, 0, 400, 400), any),
+        mockCanvasWrapper.drawPath(any, captureAny),
+        mockCanvasWrapper.restore(),
       ]);
 
       final Paint paint = verifyResult[1].captured.first;
@@ -514,17 +514,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawDots(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         barData,
         holder,
       );
 
-      verifyNever(_mockCanvasWrapper.drawDot(any, any, any));
+      verifyNever(mockCanvasWrapper.drawDot(any, any, any));
     });
 
     test('test 2', () {
@@ -544,17 +544,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawDots(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         barData,
         holder,
       );
 
-      verifyNever(_mockCanvasWrapper.drawDot(any, any, any));
+      verifyNever(mockCanvasWrapper.drawDot(any, any, any));
     });
 
     test('test 3', () {
@@ -581,17 +581,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawDots(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         barData,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawDot(any, any, any)).called(5);
+      verify(mockCanvasWrapper.drawDot(any, any, any)).called(5);
     });
 
     test('test 4', () {
@@ -623,38 +623,38 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawDots(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         barData,
         holder,
       );
 
       verifyInOrder([
-        _mockCanvasWrapper.drawDot(
+        mockCanvasWrapper.drawDot(
           any,
           const FlSpot(1, 1),
           const Offset(10, 90),
         ),
-        _mockCanvasWrapper.drawDot(
+        mockCanvasWrapper.drawDot(
           any,
           const FlSpot(2, 2),
           const Offset(20, 80),
         ),
-        _mockCanvasWrapper.drawDot(
+        mockCanvasWrapper.drawDot(
           any,
           const FlSpot(3, 3),
           const Offset(30, 70),
         ),
-        _mockCanvasWrapper.drawDot(
+        mockCanvasWrapper.drawDot(
           any,
           const FlSpot(4, 4),
           const Offset(40, 60),
         ),
-        _mockCanvasWrapper.drawDot(
+        mockCanvasWrapper.drawDot(
           any,
           const FlSpot(5, 5),
           const Offset(50, 50),
@@ -715,17 +715,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       lineChartPainter.drawTouchedSpotsIndicator(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         getDrawingInfo(data),
         holder,
       );
 
-      verifyNever(_mockCanvasWrapper.drawPath(any, any));
+      verifyNever(mockCanvasWrapper.drawPath(any, any));
     });
 
     test('test 2', () {
@@ -762,12 +762,12 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawDashedLine(
+      when(mockCanvasWrapper.drawDashedLine(
               captureAny, captureAny, captureAny, any))
           .thenAnswer((inv) {
         results.add({
@@ -780,7 +780,7 @@ void main() {
       });
 
       lineChartPainter.drawTouchedSpotsIndicator(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         getDrawingInfo(data),
         holder,
       );
@@ -827,12 +827,12 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawDashedLine(
+      when(mockCanvasWrapper.drawDashedLine(
               captureAny, captureAny, captureAny, any))
           .thenAnswer((inv) {
         results.add({
@@ -845,7 +845,7 @@ void main() {
       });
 
       lineChartPainter.drawTouchedSpotsIndicator(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         getDrawingInfo(data),
         holder,
       );
@@ -858,7 +858,7 @@ void main() {
       expect(results[1]['paint_color'], const Color(0xFF00FF00));
       expect(results[1]['paint_stroke_width'], 8.0);
 
-      verify(_mockCanvasWrapper.drawDot(any, any, any)).called(2);
+      verify(mockCanvasWrapper.drawDot(any, any, any)).called(2);
     });
   });
 
@@ -888,9 +888,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path path = lineChartPainter.generateBarPath(
         viewSize,
@@ -944,9 +944,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path path = lineChartPainter.generateBarPath(
         viewSize,
@@ -1001,9 +1001,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path path = lineChartPainter.generateNormalBarPath(
         viewSize,
@@ -1059,9 +1059,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path path = lineChartPainter.generateStepBarPath(
         viewSize,
@@ -1119,9 +1119,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path barPath = Path()
         ..moveTo(10, 10)
@@ -1168,9 +1168,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path barPath = Path()
         ..moveTo(10, 10)
@@ -1216,9 +1216,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path barPath = Path()
         ..moveTo(10, 10)
@@ -1269,9 +1269,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path belowBarPath = Path()
         ..moveTo(10, 10)
@@ -1284,11 +1284,11 @@ void main() {
         ..lineTo(10, 0)
         ..lineTo(10, 10);
 
-      lineChartPainter.drawBelowBar(_mockCanvasWrapper, belowBarPath,
+      lineChartPainter.drawBelowBar(mockCanvasWrapper, belowBarPath,
           filletAboveBarPath, holder, lineChartBarData);
 
       final result =
-          verify(_mockCanvasWrapper.drawPath(belowBarPath, captureAny));
+          verify(mockCanvasWrapper.drawPath(belowBarPath, captureAny));
       result.called(1);
 
       final paint = result.captured.single as Paint;
@@ -1340,9 +1340,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path belowBarPath = Path()
         ..moveTo(10, 10)
@@ -1356,7 +1356,7 @@ void main() {
         ..lineTo(10, 10);
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawDashedLine(
+      when(mockCanvasWrapper.drawDashedLine(
               captureAny, captureAny, captureAny, any))
           .thenAnswer((inv) {
         results.add({
@@ -1368,29 +1368,29 @@ void main() {
         });
       });
 
-      lineChartPainter.drawBelowBar(_mockCanvasWrapper, belowBarPath,
+      lineChartPainter.drawBelowBar(mockCanvasWrapper, belowBarPath,
           filletAboveBarPath, holder, lineChartBarData);
 
-      verify(_mockCanvasWrapper.saveLayer(
+      verify(mockCanvasWrapper.saveLayer(
               Rect.fromLTWH(0, 0, viewSize.width, viewSize.height), any))
           .called(1);
 
       final result =
-          verify(_mockCanvasWrapper.drawPath(belowBarPath, captureAny));
+          verify(mockCanvasWrapper.drawPath(belowBarPath, captureAny));
       result.called(1);
       final paint = result.captured.single as Paint;
       expect(paint.color, const Color(0xFF000000));
       expect(paint.shader is ui.Gradient, true);
 
       final result2 =
-          verify(_mockCanvasWrapper.drawPath(filletAboveBarPath, captureAny));
+          verify(mockCanvasWrapper.drawPath(filletAboveBarPath, captureAny));
       result2.called(1);
       final paint2 = result2.captured.single as Paint;
       expect(paint2.color, const Color(0x00000000));
       expect(paint2.blendMode, BlendMode.dstIn);
       expect(paint2.style, PaintingStyle.fill);
 
-      verify(_mockCanvasWrapper.restore()).called(1);
+      verify(mockCanvasWrapper.restore()).called(1);
 
       expect(results.length, 2);
 
@@ -1435,9 +1435,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path aboveBarPath = Path()
         ..moveTo(10, 10)
@@ -1450,11 +1450,11 @@ void main() {
         ..lineTo(10, 0)
         ..lineTo(10, 10);
 
-      lineChartPainter.drawAboveBar(_mockCanvasWrapper, aboveBarPath,
+      lineChartPainter.drawAboveBar(mockCanvasWrapper, aboveBarPath,
           filledBelowBarPath, holder, lineChartBarData);
 
       final result =
-          verify(_mockCanvasWrapper.drawPath(aboveBarPath, captureAny));
+          verify(mockCanvasWrapper.drawPath(aboveBarPath, captureAny));
       result.called(1);
 
       final paint = result.captured.single as Paint;
@@ -1506,9 +1506,9 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path aboveBarPath = Path()
         ..moveTo(10, 10)
@@ -1522,7 +1522,7 @@ void main() {
         ..lineTo(10, 10);
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawDashedLine(
+      when(mockCanvasWrapper.drawDashedLine(
               captureAny, captureAny, captureAny, any))
           .thenAnswer((inv) {
         results.add({
@@ -1534,29 +1534,29 @@ void main() {
         });
       });
 
-      lineChartPainter.drawAboveBar(_mockCanvasWrapper, aboveBarPath,
+      lineChartPainter.drawAboveBar(mockCanvasWrapper, aboveBarPath,
           filledBelowBarPath, holder, lineChartBarData);
 
-      verify(_mockCanvasWrapper.saveLayer(
+      verify(mockCanvasWrapper.saveLayer(
               Rect.fromLTWH(0, 0, viewSize.width, viewSize.height), any))
           .called(1);
 
       final result =
-          verify(_mockCanvasWrapper.drawPath(aboveBarPath, captureAny));
+          verify(mockCanvasWrapper.drawPath(aboveBarPath, captureAny));
       result.called(1);
       final paint = result.captured.single as Paint;
       expect(paint.color, const Color(0xFF000000));
       expect(paint.shader is ui.Gradient, true);
 
       final result2 =
-          verify(_mockCanvasWrapper.drawPath(filledBelowBarPath, captureAny));
+          verify(mockCanvasWrapper.drawPath(filledBelowBarPath, captureAny));
       result2.called(1);
       final paint2 = result2.captured.single as Paint;
       expect(paint2.color, const Color(0x00000000));
       expect(paint2.blendMode, BlendMode.dstIn);
       expect(paint2.style, PaintingStyle.fill);
 
-      verify(_mockCanvasWrapper.restore()).called(1);
+      verify(mockCanvasWrapper.restore()).called(1);
 
       expect(results.length, 2);
 
@@ -1619,30 +1619,30 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path aboveBarPath = Path()
         ..moveTo(10, 10)
         ..lineTo(80, 10);
 
       lineChartPainter.drawBetweenBar(
-        _mockCanvasWrapper,
+        mockCanvasWrapper,
         aboveBarPath,
         betweenBarData1,
         MockData.rect1,
         holder,
       );
 
-      verify(_mockCanvasWrapper.saveLayer(
+      verify(mockCanvasWrapper.saveLayer(
           Rect.fromLTWH(0, 0, viewSize.width, viewSize.height), any));
       final result =
-          verify(_mockCanvasWrapper.drawPath(aboveBarPath, captureAny));
+          verify(mockCanvasWrapper.drawPath(aboveBarPath, captureAny));
       result.called(1);
       final painter = result.captured.single as Paint;
       expect(painter.color, const Color(0xFFFF0000));
-      verify(_mockCanvasWrapper.restore());
+      verify(mockCanvasWrapper.restore());
     });
   });
 
@@ -1662,15 +1662,15 @@ void main() {
       );
 
       final LineChartPainter lineChartPainter = LineChartPainter();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
 
       final Path barPath = Path()
         ..moveTo(10, 10)
         ..lineTo(80, 10);
 
       lineChartPainter.drawBarShadow(
-          _mockCanvasWrapper, barPath, lineChartBarData1);
-      verifyNever(_mockCanvasWrapper.drawPath(any, any));
+          mockCanvasWrapper, barPath, lineChartBarData1);
+      verifyNever(mockCanvasWrapper.drawPath(any, any));
     });
 
     test('test 2', () {
@@ -1696,18 +1696,17 @@ void main() {
       );
 
       final LineChartPainter lineChartPainter = LineChartPainter();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path barPath = Path()
         ..moveTo(10, 10)
         ..lineTo(80, 10);
 
       lineChartPainter.drawBarShadow(
-          _mockCanvasWrapper, barPath, lineChartBarData1);
-      final result =
-          verify(_mockCanvasWrapper.drawPath(captureAny, captureAny));
+          mockCanvasWrapper, barPath, lineChartBarData1);
+      final result = verify(mockCanvasWrapper.drawPath(captureAny, captureAny));
       result.called(1);
       final path = result.captured[0] as Path;
       expect(path.getBounds(), barPath.shift(const Offset(10, 15)).getBounds());
@@ -1760,17 +1759,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path barPath = Path()
         ..moveTo(10, 10)
         ..lineTo(80, 10);
 
       lineChartPainter.drawBar(
-          _mockCanvasWrapper, barPath, lineChartBarData1, holder);
-      verifyNever(_mockCanvasWrapper.drawPath(any, any));
+          mockCanvasWrapper, barPath, lineChartBarData1, holder);
+      verifyNever(mockCanvasWrapper.drawPath(any, any));
     });
 
     test('test 2', () {
@@ -1808,18 +1807,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path barPath = Path()
         ..moveTo(10, 10)
         ..lineTo(80, 10);
 
       lineChartPainter.drawBar(
-          _mockCanvasWrapper, barPath, lineChartBarData1, holder);
-      final result =
-          verify(_mockCanvasWrapper.drawPath(captureAny, captureAny));
+          mockCanvasWrapper, barPath, lineChartBarData1, holder);
+      final result = verify(mockCanvasWrapper.drawPath(captureAny, captureAny));
       result.called(1);
       final drewPath = result.captured[0] as Path;
       expect(drewPath, barPath);
@@ -1864,18 +1862,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       final Path barPath = Path()
         ..moveTo(10, 10)
         ..lineTo(80, 10);
 
       lineChartPainter.drawBar(
-          _mockCanvasWrapper, barPath, lineChartBarData1, holder);
-      final result =
-          verify(_mockCanvasWrapper.drawPath(captureAny, captureAny));
+          mockCanvasWrapper, barPath, lineChartBarData1, holder);
+      final result = verify(mockCanvasWrapper.drawPath(captureAny, captureAny));
       result.called(1);
       final drewPath = result.captured[0] as Path;
       expect(
@@ -1905,16 +1902,16 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockBuildContext _mockBuildContext = MockBuildContext();
+      MockBuildContext mockBuildContext = MockBuildContext();
 
       lineChartPainter.drawExtraLines(
-          _mockBuildContext, _mockCanvasWrapper, holder);
+          mockBuildContext, mockCanvasWrapper, holder);
 
-      verifyNever(_mockCanvasWrapper.drawDashedLine(any, any, any, captureAny));
+      verifyNever(mockCanvasWrapper.drawDashedLine(any, any, any, captureAny));
     });
 
     test('test 2', () {
@@ -1930,16 +1927,16 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockBuildContext _mockBuildContext = MockBuildContext();
+      MockBuildContext mockBuildContext = MockBuildContext();
 
       lineChartPainter.drawExtraLines(
-          _mockBuildContext, _mockCanvasWrapper, holder);
+          mockBuildContext, mockCanvasWrapper, holder);
 
-      verifyNever(_mockCanvasWrapper.drawDashedLine(any, any, any, captureAny));
+      verifyNever(mockCanvasWrapper.drawDashedLine(any, any, any, captureAny));
     });
 
     test('test 3', () {
@@ -1963,14 +1960,14 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockBuildContext _mockBuildContext = MockBuildContext();
+      MockBuildContext mockBuildContext = MockBuildContext();
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawDashedLine(
+      when(mockCanvasWrapper.drawDashedLine(
               captureAny, captureAny, captureAny, any))
           .thenAnswer((inv) {
         results.add({
@@ -1983,7 +1980,7 @@ void main() {
       });
 
       lineChartPainter.drawExtraLines(
-          _mockBuildContext, _mockCanvasWrapper, holder);
+          mockBuildContext, mockCanvasWrapper, holder);
 
       expect(results.length, 4);
 
@@ -2057,18 +2054,18 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockBuildContext _mockBuildContext = MockBuildContext();
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockBuildContext mockBuildContext = MockBuildContext();
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenAnswer((realInvocation) => textStyle1);
-      when(_mockUtils.calculateRotationOffset(any, any))
+      when(mockUtils.calculateRotationOffset(any, any))
           .thenAnswer((realInvocation) => Offset.zero);
-      when(_mockCanvasWrapper.drawRotated(
+      when(mockCanvasWrapper.drawRotated(
         size: anyNamed('size'),
         rotationOffset: anyNamed('rotationOffset'),
         drawOffset: anyNamed('drawOffset'),
@@ -2080,8 +2077,8 @@ void main() {
         callback();
       });
       lineChartPainter.drawTouchTooltip(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         tooltipData,
         barData.spots.first,
         ShowingTooltipIndicators([
@@ -2095,7 +2092,7 @@ void main() {
       );
 
       final result1 =
-          verify(_mockCanvasWrapper.drawRRect(captureAny, captureAny));
+          verify(mockCanvasWrapper.drawRRect(captureAny, captureAny));
       result1.called(1);
       final rRect = result1.captured[0] as RRect;
       final paint = result1.captured[1] as Paint;
@@ -2104,7 +2101,7 @@ void main() {
       expect(paint.color, const Color(0x11111111));
 
       final result2 =
-          verify(_mockCanvasWrapper.drawText(captureAny, captureAny));
+          verify(mockCanvasWrapper.drawText(captureAny, captureAny));
       result2.called(1);
       final textPainter = result2.captured[0] as TextPainter;
       final drawOffset = result2.captured[1] as Offset;
@@ -2602,17 +2599,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 0);
 
-      lineChartPainter.drawGrid(_mockCanvasWrapper, holder);
-      verifyNever(_mockCanvasWrapper.drawDashedLine(any, any, any, any));
+      lineChartPainter.drawGrid(mockCanvasWrapper, holder);
+      verifyNever(mockCanvasWrapper.drawDashedLine(any, any, any, any));
     });
 
     test('test 2 - horizontal', () {
@@ -2650,17 +2647,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 0);
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawDashedLine(
+      when(mockCanvasWrapper.drawDashedLine(
               captureAny, captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
@@ -2673,7 +2670,7 @@ void main() {
         });
       });
 
-      lineChartPainter.drawGrid(_mockCanvasWrapper, holder);
+      lineChartPainter.drawGrid(mockCanvasWrapper, holder);
       expect(results.length, 2);
 
       expect(results[0]['from'], const Offset(0, 60));
@@ -2725,17 +2722,17 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 0);
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawDashedLine(
+      when(mockCanvasWrapper.drawDashedLine(
               captureAny, captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
@@ -2748,7 +2745,7 @@ void main() {
         });
       });
 
-      lineChartPainter.drawGrid(_mockCanvasWrapper, holder);
+      lineChartPainter.drawGrid(mockCanvasWrapper, holder);
       expect(results.length, 2);
 
       expect(results[0]['from'], const Offset(40, 0));
@@ -2781,19 +2778,19 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getEfficientInterval(any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getEfficientInterval(any, any))
           .thenAnswer((realInvocation) => 3);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 0);
 
-      lineChartPainter.drawGrid(_mockCanvasWrapper, holder);
-      verify(_mockCanvasWrapper.drawDashedLine(any, any, any, any)).called(6);
+      lineChartPainter.drawGrid(mockCanvasWrapper, holder);
+      verify(mockCanvasWrapper.drawDashedLine(any, any, any, any)).called(6);
     });
   });
 
@@ -2812,12 +2809,12 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      lineChartPainter.drawBackground(_mockCanvasWrapper, holder);
-      verifyNever(_mockCanvasWrapper.drawRect(any, any));
+      lineChartPainter.drawBackground(mockCanvasWrapper, holder);
+      verifyNever(mockCanvasWrapper.drawRect(any, any));
     });
 
     test('test 2', () {
@@ -2834,13 +2831,13 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      lineChartPainter.drawBackground(_mockCanvasWrapper, holder);
+      lineChartPainter.drawBackground(mockCanvasWrapper, holder);
       final result = verify(
-        _mockCanvasWrapper.drawRect(
+        mockCanvasWrapper.drawRect(
           const Rect.fromLTRB(0, 0, 20, 100),
           captureAny,
         ),
@@ -2865,12 +2862,12 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      lineChartPainter.drawRangeAnnotation(_mockCanvasWrapper, holder);
-      verifyNever(_mockCanvasWrapper.drawRect(any, any));
+      lineChartPainter.drawRangeAnnotation(mockCanvasWrapper, holder);
+      verifyNever(mockCanvasWrapper.drawRect(any, any));
     });
 
     test('test 2 - horizontal', () {
@@ -2892,12 +2889,12 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawRect(captureAny, captureAny))
+      when(mockCanvasWrapper.drawRect(captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
           'rect': inv.positionalArguments[0] as Rect,
@@ -2905,7 +2902,7 @@ void main() {
         });
       });
 
-      lineChartPainter.drawRangeAnnotation(_mockCanvasWrapper, holder);
+      lineChartPainter.drawRangeAnnotation(mockCanvasWrapper, holder);
       expect(results.length, 2);
 
       expect(results[0]['rect'], const Rect.fromLTRB(0.0, 0.0, 20.0, 60.0));
@@ -2934,12 +2931,12 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawRect(captureAny, captureAny))
+      when(mockCanvasWrapper.drawRect(captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
           'rect': inv.positionalArguments[0] as Rect,
@@ -2947,7 +2944,7 @@ void main() {
         });
       });
 
-      lineChartPainter.drawRangeAnnotation(_mockCanvasWrapper, holder);
+      lineChartPainter.drawRangeAnnotation(mockCanvasWrapper, holder);
       expect(results.length, 2);
 
       expect(results[0]['rect'], const Rect.fromLTRB(2.0, 0.0, 4.0, 100.0));
@@ -2980,12 +2977,12 @@ void main() {
 
       final LineChartPainter lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
-      lineChartPainter.drawRangeAnnotation(_mockCanvasWrapper, holder);
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      lineChartPainter.drawRangeAnnotation(mockCanvasWrapper, holder);
 
-      verify(_mockCanvasWrapper.drawRect(captureAny, captureAny)).called(4);
+      verify(mockCanvasWrapper.drawRect(captureAny, captureAny)).called(4);
     });
   });
 }

--- a/test/chart/line_chart/line_chart_painter_test.mocks.dart
+++ b/test/chart/line_chart/line_chart_painter_test.mocks.dart
@@ -395,6 +395,10 @@ class MockBuildContext extends _i1.Mock implements _i3.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i3.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i3.DiagnosticsNode describeElement(String? name,
           {_i4.DiagnosticsTreeStyle? style =
               _i4.DiagnosticsTreeStyle.errorProperty}) =>

--- a/test/chart/line_chart/line_chart_painter_test.mocks.dart
+++ b/test/chart/line_chart/line_chart_painter_test.mocks.dart
@@ -543,11 +543,11 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
   @override
   void drawTouchedSpotsIndicator(
           _i6.CanvasWrapper? canvasWrapper,
-          _i7.LineChartBarData? barData,
+          List<_i9.LineIndexDrawingInfo>? lineIndexDrawingInfo,
           _i10.PaintHolder<_i7.LineChartData>? holder) =>
       super.noSuchMethod(
-          Invocation.method(
-              #drawTouchedSpotsIndicator, [canvasWrapper, barData, holder]),
+          Invocation.method(#drawTouchedSpotsIndicator,
+              [canvasWrapper, lineIndexDrawingInfo, holder]),
           returnValueForMissingStub: null);
   @override
   _i2.Path generateBarPath(

--- a/test/chart/line_chart/line_chart_renderer_test.dart
+++ b/test/chart/line_chart/line_chart_renderer_test.dart
@@ -35,22 +35,21 @@ void main() {
 
     const textScale = 4.0;
 
-    MockBuildContext _mockBuildContext = MockBuildContext();
+    MockBuildContext mockBuildContext = MockBuildContext();
     RenderLineChart renderLineChart = RenderLineChart(
-      _mockBuildContext,
+      mockBuildContext,
       data,
       targetData,
       textScale,
     );
 
-    MockLineChartPainter _mockPainter = MockLineChartPainter();
-    MockPaintingContext _mockPaintingContext = MockPaintingContext();
-    MockCanvas _mockCanvas = MockCanvas();
-    Size _mockSize = const Size(44, 44);
-    when(_mockPaintingContext.canvas)
-        .thenAnswer((realInvocation) => _mockCanvas);
-    renderLineChart.mockTestSize = _mockSize;
-    renderLineChart.painter = _mockPainter;
+    MockLineChartPainter mockPainter = MockLineChartPainter();
+    MockPaintingContext mockPaintingContext = MockPaintingContext();
+    MockCanvas mockCanvas = MockCanvas();
+    Size mockSize = const Size(44, 44);
+    when(mockPaintingContext.canvas).thenAnswer((realInvocation) => mockCanvas);
+    renderLineChart.mockTestSize = mockSize;
+    renderLineChart.painter = mockPainter;
 
     test('test 1 correct data set', () {
       expect(renderLineChart.data == data, true);
@@ -63,27 +62,27 @@ void main() {
     });
 
     test('test 2 check paint function', () {
-      renderLineChart.paint(_mockPaintingContext, const Offset(10, 10));
-      verify(_mockCanvas.save()).called(1);
-      verify(_mockCanvas.translate(10, 10)).called(1);
-      final result = verify(_mockPainter.paint(any, captureAny, captureAny));
+      renderLineChart.paint(mockPaintingContext, const Offset(10, 10));
+      verify(mockCanvas.save()).called(1);
+      verify(mockCanvas.translate(10, 10)).called(1);
+      final result = verify(mockPainter.paint(any, captureAny, captureAny));
       expect(result.callCount, 1);
 
       final canvasWrapper = result.captured[0] as CanvasWrapper;
       expect(canvasWrapper.size, const Size(44, 44));
-      expect(canvasWrapper.canvas, _mockCanvas);
+      expect(canvasWrapper.canvas, mockCanvas);
 
       final paintHolder = result.captured[1] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);
       expect(paintHolder.textScale, textScale);
 
-      verify(_mockCanvas.restore()).called(1);
+      verify(mockCanvas.restore()).called(1);
     });
 
     test('test 3 check getResponseAtLocation function', () {
       List<Map<String, dynamic>> results = [];
-      when(_mockPainter.handleTouch(captureAny, captureAny, captureAny))
+      when(mockPainter.handleTouch(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
           'local_position': inv.positionalArguments[0] as Offset,
@@ -99,7 +98,7 @@ void main() {
         MockData.lineTouchResponse1.lineBarSpots,
       );
       expect(results[0]['local_position'] as Offset, MockData.offset1);
-      expect(results[0]['size'] as Size, _mockSize);
+      expect(results[0]['size'] as Size, mockSize);
       final paintHolder = results[0]['paint_holder'] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);

--- a/test/chart/line_chart/line_chart_renderer_test.mocks.dart
+++ b/test/chart/line_chart/line_chart_renderer_test.mocks.dart
@@ -5,15 +5,16 @@
 import 'dart:typed_data' as _i7;
 import 'dart:ui' as _i2;
 
-import 'package:fl_chart/fl_chart.dart' as _i12;
+import 'package:fl_chart/fl_chart.dart' as _i13;
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart'
-    as _i11;
-import 'package:fl_chart/src/chart/line_chart/line_chart_painter.dart' as _i9;
-import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i10;
+    as _i12;
+import 'package:fl_chart/src/chart/line_chart/line_chart_painter.dart' as _i10;
+import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i11;
 import 'package:flutter/foundation.dart' as _i5;
 import 'package:flutter/material.dart' as _i6;
 import 'package:flutter/rendering.dart' as _i3;
 import 'package:flutter/src/rendering/layer.dart' as _i4;
+import 'package:flutter/src/widgets/notification_listener.dart' as _i9;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:vector_math/vector_math_64.dart' as _i8;
 
@@ -437,6 +438,10 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i9.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i5.DiagnosticsNode describeElement(String? name,
           {_i5.DiagnosticsTreeStyle? style =
               _i5.DiagnosticsTreeStyle.errorProperty}) =>
@@ -466,54 +471,54 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
 /// A class which mocks [LineChartPainter].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
+class MockLineChartPainter extends _i1.Mock implements _i10.LineChartPainter {
   MockLineChartPainter() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void paint(_i6.BuildContext? context, _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+  void paint(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#paint, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void clipToBorder(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+  void clipToBorder(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#clipToBorder, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
   void drawBarLine(
-          _i10.CanvasWrapper? canvasWrapper,
-          _i12.LineChartBarData? barData,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          _i13.LineChartBarData? barData,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawBarLine, [canvasWrapper, barData, holder]),
           returnValueForMissingStub: null);
   @override
   void drawBetweenBarsArea(
-          _i10.CanvasWrapper? canvasWrapper,
-          _i12.LineChartData? data,
-          _i12.BetweenBarsData? betweenBarsData,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          _i13.LineChartData? data,
+          _i13.BetweenBarsData? betweenBarsData,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawBetweenBarsArea,
               [canvasWrapper, data, betweenBarsData, holder]),
           returnValueForMissingStub: null);
   @override
   void drawDots(
-          _i10.CanvasWrapper? canvasWrapper,
-          _i12.LineChartBarData? barData,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          _i13.LineChartBarData? barData,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawDots, [canvasWrapper, barData, holder]),
           returnValueForMissingStub: null);
   @override
   void drawTouchedSpotsIndicator(
-          _i10.CanvasWrapper? canvasWrapper,
-          List<_i9.LineIndexDrawingInfo>? lineIndexDrawingInfo,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          List<_i10.LineIndexDrawingInfo>? lineIndexDrawingInfo,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawTouchedSpotsIndicator,
               [canvasWrapper, lineIndexDrawingInfo, holder]),
@@ -521,9 +526,9 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
   @override
   _i2.Path generateBarPath(
           _i2.Size? viewSize,
-          _i12.LineChartBarData? barData,
-          List<_i12.FlSpot>? barSpots,
-          _i11.PaintHolder<_i12.LineChartData>? holder,
+          _i13.LineChartBarData? barData,
+          List<_i13.FlSpot>? barSpots,
+          _i12.PaintHolder<_i13.LineChartData>? holder,
           {_i2.Path? appendToPath}) =>
       (super.noSuchMethod(
           Invocation.method(
@@ -534,9 +539,9 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
   @override
   _i2.Path generateNormalBarPath(
           _i2.Size? viewSize,
-          _i12.LineChartBarData? barData,
-          List<_i12.FlSpot>? barSpots,
-          _i11.PaintHolder<_i12.LineChartData>? holder,
+          _i13.LineChartBarData? barData,
+          List<_i13.FlSpot>? barSpots,
+          _i12.PaintHolder<_i13.LineChartData>? holder,
           {_i2.Path? appendToPath}) =>
       (super.noSuchMethod(
           Invocation.method(
@@ -547,9 +552,9 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
   @override
   _i2.Path generateStepBarPath(
           _i2.Size? viewSize,
-          _i12.LineChartBarData? barData,
-          List<_i12.FlSpot>? barSpots,
-          _i11.PaintHolder<_i12.LineChartData>? holder,
+          _i13.LineChartBarData? barData,
+          List<_i13.FlSpot>? barSpots,
+          _i12.PaintHolder<_i13.LineChartData>? holder,
           {_i2.Path? appendToPath}) =>
       (super.noSuchMethod(
           Invocation.method(
@@ -560,10 +565,10 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
   @override
   _i2.Path generateBelowBarPath(
           _i2.Size? viewSize,
-          _i12.LineChartBarData? barData,
+          _i13.LineChartBarData? barData,
           _i2.Path? barPath,
-          List<_i12.FlSpot>? barSpots,
-          _i11.PaintHolder<_i12.LineChartData>? holder,
+          List<_i13.FlSpot>? barSpots,
+          _i12.PaintHolder<_i13.LineChartData>? holder,
           {bool? fillCompletely = false}) =>
       (super.noSuchMethod(
           Invocation.method(
@@ -574,10 +579,10 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
   @override
   _i2.Path generateAboveBarPath(
           _i2.Size? viewSize,
-          _i12.LineChartBarData? barData,
+          _i13.LineChartBarData? barData,
           _i2.Path? barPath,
-          List<_i12.FlSpot>? barSpots,
-          _i11.PaintHolder<_i12.LineChartData>? holder,
+          List<_i13.FlSpot>? barSpots,
+          _i12.PaintHolder<_i13.LineChartData>? holder,
           {bool? fillCompletely = false}) =>
       (super.noSuchMethod(
           Invocation.method(
@@ -587,11 +592,11 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
           returnValue: _FakePath_8()) as _i2.Path);
   @override
   void drawBelowBar(
-          _i10.CanvasWrapper? canvasWrapper,
+          _i11.CanvasWrapper? canvasWrapper,
           _i2.Path? belowBarPath,
           _i2.Path? filledAboveBarPath,
-          _i11.PaintHolder<_i12.LineChartData>? holder,
-          _i12.LineChartBarData? barData) =>
+          _i12.PaintHolder<_i13.LineChartData>? holder,
+          _i13.LineChartBarData? barData) =>
       super.noSuchMethod(
           Invocation.method(#drawBelowBar, [
             canvasWrapper,
@@ -603,11 +608,11 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
           returnValueForMissingStub: null);
   @override
   void drawAboveBar(
-          _i10.CanvasWrapper? canvasWrapper,
+          _i11.CanvasWrapper? canvasWrapper,
           _i2.Path? aboveBarPath,
           _i2.Path? filledBelowBarPath,
-          _i11.PaintHolder<_i12.LineChartData>? holder,
-          _i12.LineChartBarData? barData) =>
+          _i12.PaintHolder<_i13.LineChartData>? holder,
+          _i13.LineChartBarData? barData) =>
       super.noSuchMethod(
           Invocation.method(#drawAboveBar, [
             canvasWrapper,
@@ -619,27 +624,27 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
           returnValueForMissingStub: null);
   @override
   void drawBetweenBar(
-          _i10.CanvasWrapper? canvasWrapper,
+          _i11.CanvasWrapper? canvasWrapper,
           _i2.Path? barPath,
-          _i12.BetweenBarsData? betweenBarsData,
+          _i13.BetweenBarsData? betweenBarsData,
           _i2.Rect? aroundRect,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawBetweenBar,
               [canvasWrapper, barPath, betweenBarsData, aroundRect, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawBarShadow(_i10.CanvasWrapper? canvasWrapper, _i2.Path? barPath,
-          _i12.LineChartBarData? barData) =>
+  void drawBarShadow(_i11.CanvasWrapper? canvasWrapper, _i2.Path? barPath,
+          _i13.LineChartBarData? barData) =>
       super.noSuchMethod(
           Invocation.method(#drawBarShadow, [canvasWrapper, barPath, barData]),
           returnValueForMissingStub: null);
   @override
   void drawBar(
-          _i10.CanvasWrapper? canvasWrapper,
+          _i11.CanvasWrapper? canvasWrapper,
           _i2.Path? barPath,
-          _i12.LineChartBarData? barData,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i13.LineChartBarData? barData,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(
               #drawBar, [canvasWrapper, barPath, barData, holder]),
@@ -647,19 +652,19 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
   @override
   void drawExtraLines(
           _i6.BuildContext? context,
-          _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawExtraLines, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
   void drawTouchTooltip(
           _i6.BuildContext? context,
-          _i10.CanvasWrapper? canvasWrapper,
-          _i12.LineTouchTooltipData? tooltipData,
-          _i12.FlSpot? showOnSpot,
-          _i12.ShowingTooltipIndicators? showingTooltipSpots,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          _i13.LineTouchTooltipData? tooltipData,
+          _i13.FlSpot? showOnSpot,
+          _i13.ShowingTooltipIndicators? showingTooltipSpots,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawTouchTooltip, [
             context,
@@ -672,59 +677,59 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
           returnValueForMissingStub: null);
   @override
   double getBarLineXLength(
-          _i12.LineChartBarData? barData,
+          _i13.LineChartBarData? barData,
           _i2.Size? chartUsableSize,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(
               #getBarLineXLength, [barData, chartUsableSize, holder]),
           returnValue: 0.0) as double);
   @override
-  List<_i12.TouchLineBarSpot>? handleTouch(_i2.Offset? localPosition,
-          _i2.Size? size, _i11.PaintHolder<_i12.LineChartData>? holder) =>
+  List<_i13.TouchLineBarSpot>? handleTouch(_i2.Offset? localPosition,
+          _i2.Size? size, _i12.PaintHolder<_i13.LineChartData>? holder) =>
       (super.noSuchMethod(
               Invocation.method(#handleTouch, [localPosition, size, holder]))
-          as List<_i12.TouchLineBarSpot>?);
+          as List<_i13.TouchLineBarSpot>?);
   @override
-  _i12.TouchLineBarSpot? getNearestTouchedSpot(
+  _i13.TouchLineBarSpot? getNearestTouchedSpot(
           _i2.Size? viewSize,
           _i2.Offset? touchedPoint,
-          _i12.LineChartBarData? barData,
+          _i13.LineChartBarData? barData,
           int? barDataPosition,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       (super.noSuchMethod(Invocation.method(#getNearestTouchedSpot, [
         viewSize,
         touchedPoint,
         barData,
         barDataPosition,
         holder
-      ])) as _i12.TouchLineBarSpot?);
+      ])) as _i13.TouchLineBarSpot?);
   @override
-  void drawGrid(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+  void drawGrid(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(Invocation.method(#drawGrid, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawBackground(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+  void drawBackground(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawBackground, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawRangeAnnotation(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+  void drawRangeAnnotation(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawRangeAnnotation, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
   double getPixelX(double? spotX, _i2.Size? viewSize,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#getPixelX, [spotX, viewSize, holder]),
           returnValue: 0.0) as double);
   @override
   double getPixelY(double? spotY, _i2.Size? viewSize,
-          _i11.PaintHolder<_i12.LineChartData>? holder) =>
+          _i12.PaintHolder<_i13.LineChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#getPixelY, [spotY, viewSize, holder]),
           returnValue: 0.0) as double);

--- a/test/chart/line_chart/line_chart_renderer_test.mocks.dart
+++ b/test/chart/line_chart/line_chart_renderer_test.mocks.dart
@@ -512,11 +512,11 @@ class MockLineChartPainter extends _i1.Mock implements _i9.LineChartPainter {
   @override
   void drawTouchedSpotsIndicator(
           _i10.CanvasWrapper? canvasWrapper,
-          _i12.LineChartBarData? barData,
+          List<_i9.LineIndexDrawingInfo>? lineIndexDrawingInfo,
           _i11.PaintHolder<_i12.LineChartData>? holder) =>
       super.noSuchMethod(
-          Invocation.method(
-              #drawTouchedSpotsIndicator, [canvasWrapper, barData, holder]),
+          Invocation.method(#drawTouchedSpotsIndicator,
+              [canvasWrapper, lineIndexDrawingInfo, holder]),
           returnValueForMissingStub: null);
   @override
   _i2.Path generateBarPath(

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -33,23 +33,23 @@ void main() {
       final pieChartPainter = PieChartPainter();
       final holder = PaintHolder<PieChartData>(data, data, 1.0);
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenAnswer((realInvocation) => textStyle1);
-      when(_mockUtils.radians(any)).thenAnswer((realInvocation) => 12);
+      when(mockUtils.radians(any)).thenAnswer((realInvocation) => 12);
 
-      final _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       pieChartPainter.paint(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawPath(any, any)).called(3);
+      verify(mockCanvasWrapper.drawPath(any, any)).called(3);
       Utils.changeInstance(utilsMainInstance);
     });
   });
@@ -93,13 +93,13 @@ void main() {
       final PieChartPainter barChartPainter = PieChartPainter();
       final holder = PaintHolder<PieChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
-      barChartPainter.drawCenterSpace(_mockCanvasWrapper, 10, holder);
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      barChartPainter.drawCenterSpace(mockCanvasWrapper, 10, holder);
 
-      final result = verify(_mockCanvasWrapper.drawCircle(
-          const Offset(100, 100), 10, captureAny));
+      final result = verify(
+          mockCanvasWrapper.drawCircle(const Offset(100, 100), 10, captureAny));
       expect(result.callCount, 1);
       expect((result.captured.first as Paint).color, MockData.color1);
     });
@@ -119,12 +119,12 @@ void main() {
       final PieChartPainter barChartPainter = PieChartPainter();
       final holder = PaintHolder<PieChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
-      barChartPainter.drawSections(_mockCanvasWrapper, [360], 10, holder);
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      barChartPainter.drawSections(mockCanvasWrapper, [360], 10, holder);
 
-      final result = verify(_mockCanvasWrapper.drawCircle(
+      final result = verify(mockCanvasWrapper.drawCircle(
           const Offset(100, 100), 10 + 15, captureAny));
       expect(result.callCount, 1);
       expect((result.captured.single as Paint).color, MockData.color2);
@@ -148,11 +148,11 @@ void main() {
       final PieChartPainter barChartPainter = PieChartPainter();
       final holder = PaintHolder<PieChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawPath(captureAny, captureAny))
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
           .thenAnswer((inv) {
         final paint = inv.positionalArguments[1] as Paint;
         results.add({
@@ -163,8 +163,8 @@ void main() {
       });
 
       barChartPainter.drawSections(
-          _mockCanvasWrapper, [36, 72, 108, 144], 10, holder);
-      verifyNever(_mockCanvasWrapper.drawCircle(any, any, any));
+          mockCanvasWrapper, [36, 72, 108, 144], 10, holder);
+      verifyNever(mockCanvasWrapper.drawCircle(any, any, any));
 
       expect(results.length, 4);
 
@@ -384,12 +384,12 @@ void main() {
           ]);
       final PieChartPainter barChartPainter = PieChartPainter();
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawPath(captureAny, captureAny))
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
           .thenAnswer((inv) {
         final paint = inv.positionalArguments[1] as Paint;
         results.add({
@@ -400,13 +400,13 @@ void main() {
       });
 
       barChartPainter.drawSection(
-          data.sections[0], MockData.path1, _mockCanvasWrapper);
+          data.sections[0], MockData.path1, mockCanvasWrapper);
       barChartPainter.drawSection(
-          data.sections[1], MockData.path2, _mockCanvasWrapper);
+          data.sections[1], MockData.path2, mockCanvasWrapper);
       barChartPainter.drawSection(
-          data.sections[2], MockData.path3, _mockCanvasWrapper);
+          data.sections[2], MockData.path3, mockCanvasWrapper);
       barChartPainter.drawSection(
-          data.sections[3], MockData.path4, _mockCanvasWrapper);
+          data.sections[3], MockData.path4, mockCanvasWrapper);
 
       expect(results.length, 4);
 
@@ -442,12 +442,12 @@ void main() {
           ]);
       final PieChartPainter barChartPainter = PieChartPainter();
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawPath(captureAny, captureAny))
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
           .thenAnswer((inv) {
         final paint = inv.positionalArguments[1] as Paint;
         results.add({
@@ -458,18 +458,18 @@ void main() {
       });
 
       barChartPainter.drawSectionStroke(
-          data.sections[0], MockData.path1, _mockCanvasWrapper, viewSize);
+          data.sections[0], MockData.path1, mockCanvasWrapper, viewSize);
       barChartPainter.drawSectionStroke(
-          data.sections[1], MockData.path2, _mockCanvasWrapper, viewSize);
+          data.sections[1], MockData.path2, mockCanvasWrapper, viewSize);
       barChartPainter.drawSectionStroke(
-          data.sections[2], MockData.path3, _mockCanvasWrapper, viewSize);
+          data.sections[2], MockData.path3, mockCanvasWrapper, viewSize);
       barChartPainter.drawSectionStroke(
-          data.sections[3], MockData.path4, _mockCanvasWrapper, viewSize);
+          data.sections[3], MockData.path4, mockCanvasWrapper, viewSize);
 
-      verifyNever(_mockCanvasWrapper.saveLayer(any, any));
-      verifyNever(_mockCanvasWrapper.clipPath(any));
-      verifyNever(_mockCanvasWrapper.drawPath(any, any));
-      verifyNever(_mockCanvasWrapper.restore());
+      verifyNever(mockCanvasWrapper.saveLayer(any, any));
+      verifyNever(mockCanvasWrapper.clipPath(any));
+      verifyNever(mockCanvasWrapper.drawPath(any, any));
+      verifyNever(mockCanvasWrapper.restore());
     });
 
     test('test 2', () {
@@ -498,19 +498,19 @@ void main() {
       );
       final PieChartPainter barChartPainter = PieChartPainter();
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
       List<Map<String, dynamic>> clipPathResults = [];
-      when(_mockCanvasWrapper.clipPath(captureAny)).thenAnswer((inv) {
+      when(mockCanvasWrapper.clipPath(captureAny)).thenAnswer((inv) {
         clipPathResults.add({
           'path': inv.positionalArguments[0] as Path,
         });
       });
 
       List<Map<String, dynamic>> drawPathResults = [];
-      when(_mockCanvasWrapper.drawPath(captureAny, captureAny))
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
           .thenAnswer((inv) {
         final paint = inv.positionalArguments[1] as Paint;
         drawPathResults.add({
@@ -522,15 +522,15 @@ void main() {
       });
 
       barChartPainter.drawSectionStroke(
-          data.sections[0], MockData.path1, _mockCanvasWrapper, viewSize);
+          data.sections[0], MockData.path1, mockCanvasWrapper, viewSize);
       barChartPainter.drawSectionStroke(
-          data.sections[1], MockData.path2, _mockCanvasWrapper, viewSize);
+          data.sections[1], MockData.path2, mockCanvasWrapper, viewSize);
       barChartPainter.drawSectionStroke(
-          data.sections[2], MockData.path3, _mockCanvasWrapper, viewSize);
+          data.sections[2], MockData.path3, mockCanvasWrapper, viewSize);
       barChartPainter.drawSectionStroke(
-          data.sections[3], MockData.path4, _mockCanvasWrapper, viewSize);
+          data.sections[3], MockData.path4, mockCanvasWrapper, viewSize);
 
-      verify(_mockCanvasWrapper.saveLayer(
+      verify(mockCanvasWrapper.saveLayer(
               Rect.fromLTWH(0, 0, viewSize.width, viewSize.height), any))
           .called(4);
       expect(clipPathResults.length, 4);
@@ -565,7 +565,7 @@ void main() {
       expect(drawPathResults[3]['paint_stroke_width'],
           MockData.borderSide4.width * 2);
 
-      verify(_mockCanvasWrapper.restore()).called(4);
+      verify(mockCanvasWrapper.restore()).called(4);
     });
   });
 

--- a/test/chart/pie_chart/pie_chart_painter_test.mocks.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.mocks.dart
@@ -390,6 +390,10 @@ class MockBuildContext extends _i1.Mock implements _i3.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i3.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i3.DiagnosticsNode describeElement(String? name,
           {_i4.DiagnosticsTreeStyle? style =
               _i4.DiagnosticsTreeStyle.errorProperty}) =>

--- a/test/chart/pie_chart/pie_chart_renderer_test.dart
+++ b/test/chart/pie_chart/pie_chart_renderer_test.dart
@@ -19,22 +19,21 @@ void main() {
 
     const textScale = 4.0;
 
-    MockBuildContext _mockBuildContext = MockBuildContext();
+    MockBuildContext mockBuildContext = MockBuildContext();
     RenderPieChart renderBarChart = RenderPieChart(
-      _mockBuildContext,
+      mockBuildContext,
       data,
       targetData,
       textScale,
     );
 
-    MockPieChartPainter _mockPainter = MockPieChartPainter();
-    MockPaintingContext _mockPaintingContext = MockPaintingContext();
-    MockCanvas _mockCanvas = MockCanvas();
-    Size _mockSize = const Size(44, 44);
-    when(_mockPaintingContext.canvas)
-        .thenAnswer((realInvocation) => _mockCanvas);
-    renderBarChart.mockTestSize = _mockSize;
-    renderBarChart.painter = _mockPainter;
+    MockPieChartPainter mockPainter = MockPieChartPainter();
+    MockPaintingContext mockPaintingContext = MockPaintingContext();
+    MockCanvas mockCanvas = MockCanvas();
+    Size mockSize = const Size(44, 44);
+    when(mockPaintingContext.canvas).thenAnswer((realInvocation) => mockCanvas);
+    renderBarChart.mockTestSize = mockSize;
+    renderBarChart.painter = mockPainter;
 
     test('test 1 correct data set', () {
       expect(renderBarChart.data == data, true);
@@ -47,27 +46,27 @@ void main() {
     });
 
     test('test 2 check paint function', () {
-      renderBarChart.paint(_mockPaintingContext, const Offset(10, 10));
-      verify(_mockCanvas.save()).called(1);
-      verify(_mockCanvas.translate(10, 10)).called(1);
-      final result = verify(_mockPainter.paint(any, captureAny, captureAny));
+      renderBarChart.paint(mockPaintingContext, const Offset(10, 10));
+      verify(mockCanvas.save()).called(1);
+      verify(mockCanvas.translate(10, 10)).called(1);
+      final result = verify(mockPainter.paint(any, captureAny, captureAny));
       expect(result.callCount, 1);
 
       final canvasWrapper = result.captured[0] as CanvasWrapper;
       expect(canvasWrapper.size, const Size(44, 44));
-      expect(canvasWrapper.canvas, _mockCanvas);
+      expect(canvasWrapper.canvas, mockCanvas);
 
       final paintHolder = result.captured[1] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);
       expect(paintHolder.textScale, textScale);
 
-      verify(_mockCanvas.restore()).called(1);
+      verify(mockCanvas.restore()).called(1);
     });
 
     test('test 3 check getResponseAtLocation function', () {
       List<Map<String, dynamic>> results = [];
-      when(_mockPainter.handleTouch(captureAny, captureAny, captureAny))
+      when(mockPainter.handleTouch(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
           'local_position': inv.positionalArguments[0] as Offset,
@@ -80,7 +79,7 @@ void main() {
           renderBarChart.getResponseAtLocation(MockData.offset1);
       expect(touchResponse.touchedSection, MockData.pieTouchedSection1);
       expect(results[0]['local_position'] as Offset, MockData.offset1);
-      expect(results[0]['size'] as Size, _mockSize);
+      expect(results[0]['size'] as Size, mockSize);
       final paintHolder = results[0]['paint_holder'] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);

--- a/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
+++ b/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
@@ -6,15 +6,16 @@ import 'dart:typed_data' as _i8;
 import 'dart:ui' as _i2;
 
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart'
-    as _i12;
-import 'package:fl_chart/src/chart/base/line.dart' as _i13;
+    as _i13;
+import 'package:fl_chart/src/chart/base/line.dart' as _i14;
 import 'package:fl_chart/src/chart/pie_chart/pie_chart_data.dart' as _i7;
-import 'package:fl_chart/src/chart/pie_chart/pie_chart_painter.dart' as _i10;
-import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i11;
+import 'package:fl_chart/src/chart/pie_chart/pie_chart_painter.dart' as _i11;
+import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i12;
 import 'package:flutter/foundation.dart' as _i5;
 import 'package:flutter/material.dart' as _i6;
 import 'package:flutter/rendering.dart' as _i3;
 import 'package:flutter/src/rendering/layer.dart' as _i4;
+import 'package:flutter/src/widgets/notification_listener.dart' as _i10;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:vector_math/vector_math_64.dart' as _i9;
 
@@ -441,6 +442,10 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i10.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i5.DiagnosticsNode describeElement(String? name,
           {_i5.DiagnosticsTreeStyle? style =
               _i5.DiagnosticsTreeStyle.errorProperty}) =>
@@ -470,14 +475,14 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
 /// A class which mocks [PieChartPainter].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPieChartPainter extends _i1.Mock implements _i10.PieChartPainter {
+class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
   MockPieChartPainter() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void paint(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
-          _i12.PaintHolder<_i7.PieChartData>? holder) =>
+  void paint(_i6.BuildContext? context, _i12.CanvasWrapper? canvasWrapper,
+          _i13.PaintHolder<_i7.PieChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#paint, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
@@ -488,18 +493,18 @@ class MockPieChartPainter extends _i1.Mock implements _i10.PieChartPainter {
           Invocation.method(#calculateSectionsAngle, [sections, sumValue]),
           returnValue: <double>[]) as List<double>);
   @override
-  void drawCenterSpace(_i11.CanvasWrapper? canvasWrapper, double? centerRadius,
-          _i12.PaintHolder<_i7.PieChartData>? holder) =>
+  void drawCenterSpace(_i12.CanvasWrapper? canvasWrapper, double? centerRadius,
+          _i13.PaintHolder<_i7.PieChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(
               #drawCenterSpace, [canvasWrapper, centerRadius, holder]),
           returnValueForMissingStub: null);
   @override
   void drawSections(
-          _i11.CanvasWrapper? canvasWrapper,
+          _i12.CanvasWrapper? canvasWrapper,
           List<double>? sectionsAngle,
           double? centerRadius,
-          _i12.PaintHolder<_i7.PieChartData>? holder) =>
+          _i13.PaintHolder<_i7.PieChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawSections,
               [canvasWrapper, sectionsAngle, centerRadius, holder]),
@@ -523,12 +528,12 @@ class MockPieChartPainter extends _i1.Mock implements _i10.PieChartPainter {
           ]),
           returnValue: _FakePath_8()) as _i2.Path);
   @override
-  _i2.Path createRectPathAroundLine(_i13.Line? line, double? width) => (super
+  _i2.Path createRectPathAroundLine(_i14.Line? line, double? width) => (super
       .noSuchMethod(Invocation.method(#createRectPathAroundLine, [line, width]),
           returnValue: _FakePath_8()) as _i2.Path);
   @override
   void drawSection(_i7.PieChartSectionData? section, _i2.Path? sectionPath,
-          _i11.CanvasWrapper? canvasWrapper) =>
+          _i12.CanvasWrapper? canvasWrapper) =>
       super.noSuchMethod(
           Invocation.method(
               #drawSection, [section, sectionPath, canvasWrapper]),
@@ -537,34 +542,34 @@ class MockPieChartPainter extends _i1.Mock implements _i10.PieChartPainter {
   void drawSectionStroke(
           _i7.PieChartSectionData? section,
           _i2.Path? sectionPath,
-          _i11.CanvasWrapper? canvasWrapper,
+          _i12.CanvasWrapper? canvasWrapper,
           _i2.Size? viewSize) =>
       super.noSuchMethod(
           Invocation.method(#drawSectionStroke,
               [section, sectionPath, canvasWrapper, viewSize]),
           returnValueForMissingStub: null);
   @override
-  void drawTexts(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
-          _i12.PaintHolder<_i7.PieChartData>? holder, double? centerRadius) =>
+  void drawTexts(_i6.BuildContext? context, _i12.CanvasWrapper? canvasWrapper,
+          _i13.PaintHolder<_i7.PieChartData>? holder, double? centerRadius) =>
       super.noSuchMethod(
           Invocation.method(
               #drawTexts, [context, canvasWrapper, holder, centerRadius]),
           returnValueForMissingStub: null);
   @override
   double calculateCenterRadius(
-          _i2.Size? viewSize, _i12.PaintHolder<_i7.PieChartData>? holder) =>
+          _i2.Size? viewSize, _i13.PaintHolder<_i7.PieChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#calculateCenterRadius, [viewSize, holder]),
           returnValue: 0.0) as double);
   @override
   _i7.PieTouchedSection handleTouch(_i2.Offset? localPosition,
-          _i2.Size? viewSize, _i12.PaintHolder<_i7.PieChartData>? holder) =>
+          _i2.Size? viewSize, _i13.PaintHolder<_i7.PieChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#handleTouch, [localPosition, viewSize, holder]),
           returnValue: _FakePieTouchedSection_9()) as _i7.PieTouchedSection);
   @override
   Map<int, _i2.Offset> getBadgeOffsets(
-          _i2.Size? viewSize, _i12.PaintHolder<_i7.PieChartData>? holder) =>
+          _i2.Size? viewSize, _i13.PaintHolder<_i7.PieChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#getBadgeOffsets, [viewSize, holder]),
           returnValue: <int, _i2.Offset>{}) as Map<int, _i2.Offset>);

--- a/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
+++ b/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
@@ -12,9 +12,9 @@ import 'package:fl_chart/src/chart/pie_chart/pie_chart_data.dart' as _i7;
 import 'package:fl_chart/src/chart/pie_chart/pie_chart_painter.dart' as _i10;
 import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i11;
 import 'package:flutter/foundation.dart' as _i5;
+import 'package:flutter/material.dart' as _i6;
 import 'package:flutter/rendering.dart' as _i3;
 import 'package:flutter/src/rendering/layer.dart' as _i4;
-import 'package:flutter/widgets.dart' as _i6;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:vector_math/vector_math_64.dart' as _i9;
 

--- a/test/chart/radar_chart/radar_chart_painter_test.dart
+++ b/test/chart/radar_chart/radar_chart_painter_test.dart
@@ -45,35 +45,35 @@ void main() {
       final radarPainter = RadarChartPainter();
       final holder = PaintHolder<RadarChartData>(data, data, 1.0);
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenAnswer((realInvocation) => textStyle1);
-      when(_mockUtils.calculateRotationOffset(any, any))
+      when(mockUtils.calculateRotationOffset(any, any))
           .thenAnswer((realInvocation) => Offset.zero);
-      when(_mockUtils.convertRadiusToSigma(any))
+      when(mockUtils.convertRadiusToSigma(any))
           .thenAnswer((realInvocation) => 4.0);
-      when(_mockUtils.getEfficientInterval(any, any))
+      when(mockUtils.getEfficientInterval(any, any))
           .thenAnswer((realInvocation) => 1.0);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 1.0);
-      when(_mockUtils.normalizeBorderRadius(any, any))
+      when(mockUtils.normalizeBorderRadius(any, any))
           .thenAnswer((realInvocation) => BorderRadius.zero);
-      when(_mockUtils.normalizeBorderSide(any, any)).thenAnswer(
+      when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
           (realInvocation) => const BorderSide(color: MockData.color0));
 
-      final _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       radarPainter.paint(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawCircle(any, any, any)).called(12);
-      verify(_mockCanvasWrapper.drawLine(any, any, any)).called(7);
+      verify(mockCanvasWrapper.drawCircle(any, any, any)).called(12);
+      verify(mockCanvasWrapper.drawLine(any, any, any)).called(7);
       Utils.changeInstance(utilsMainInstance);
     });
   });
@@ -108,19 +108,19 @@ void main() {
       final RadarChartPainter radarChartPainter = RadarChartPainter();
       final holder = PaintHolder<RadarChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenReturn(MockData.textStyle1);
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
-      MockBuildContext _mockContext = MockBuildContext();
+      MockBuildContext mockContext = MockBuildContext();
 
       List<Map<String, dynamic>> drawCircleResults = [];
-      when(_mockCanvasWrapper.drawCircle(captureAny, captureAny, captureAny))
+      when(mockCanvasWrapper.drawCircle(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         drawCircleResults.add({
           'offset': inv.positionalArguments[0] as Offset,
@@ -131,7 +131,7 @@ void main() {
         });
       });
 
-      radarChartPainter.drawTicks(_mockContext, _mockCanvasWrapper, holder);
+      radarChartPainter.drawTicks(mockContext, mockCanvasWrapper, holder);
 
       expect(drawCircleResults.length, 3);
 
@@ -155,8 +155,7 @@ void main() {
       expect(drawCircleResults[2]['paint_stroke'], 55);
       expect(drawCircleResults[2]['paint_style'], PaintingStyle.stroke);
 
-      final result =
-          verify(_mockCanvasWrapper.drawText(captureAny, captureAny));
+      final result = verify(mockCanvasWrapper.drawText(captureAny, captureAny));
       expect(result.callCount, 1);
       final tp = result.captured[0] as TextPainter;
       expect((tp.text as TextSpan).text, '1.0');
@@ -196,17 +195,17 @@ void main() {
       final RadarChartPainter radarChartPainter = RadarChartPainter();
       final holder = PaintHolder<RadarChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenReturn(MockData.textStyle1);
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
       List<Map<String, dynamic>> drawLineResults = [];
-      when(_mockCanvasWrapper.drawLine(captureAny, captureAny, captureAny))
+      when(mockCanvasWrapper.drawLine(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         drawLineResults.add({
           'offset_from': inv.positionalArguments[0] as Offset,
@@ -217,7 +216,7 @@ void main() {
         });
       });
 
-      radarChartPainter.drawGrids(_mockCanvasWrapper, holder);
+      radarChartPainter.drawGrids(mockCanvasWrapper, holder);
       expect(drawLineResults.length, 3);
 
       expect(drawLineResults[0]['offset_from'], const Offset(200, 150));
@@ -275,21 +274,21 @@ void main() {
       final RadarChartPainter radarChartPainter = RadarChartPainter();
       final holder = PaintHolder<RadarChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
           (realInvocation) =>
               realInvocation.positionalArguments[1] as TextStyle);
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
-      final _mockContext = MockBuildContext();
+      final mockContext = MockBuildContext();
 
-      radarChartPainter.drawTitles(_mockContext, _mockCanvasWrapper, holder);
+      radarChartPainter.drawTitles(mockContext, mockCanvasWrapper, holder);
 
-      verifyNever(_mockCanvasWrapper.drawText(any, any));
+      verifyNever(mockCanvasWrapper.drawText(any, any));
     });
 
     test('test 2', () {
@@ -326,20 +325,20 @@ void main() {
       final RadarChartPainter radarChartPainter = RadarChartPainter();
       final holder = PaintHolder<RadarChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
           (realInvocation) =>
               realInvocation.positionalArguments[1] as TextStyle);
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
-      final _mockContext = MockBuildContext();
+      final mockContext = MockBuildContext();
 
       List<Map<String, dynamic>> results = [];
-      when(_mockCanvasWrapper.drawText(captureAny, captureAny))
+      when(mockCanvasWrapper.drawText(captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
           'tp_text':
@@ -351,7 +350,7 @@ void main() {
         });
       });
 
-      radarChartPainter.drawTitles(_mockContext, _mockCanvasWrapper, holder);
+      radarChartPainter.drawTitles(mockContext, mockCanvasWrapper, holder);
       expect(results.length, 3);
 
       expect(results[0]['tp_text'] as String, '00');
@@ -415,18 +414,18 @@ void main() {
       final RadarChartPainter radarChartPainter = RadarChartPainter();
       final holder = PaintHolder<RadarChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
           (realInvocation) =>
               realInvocation.positionalArguments[1] as TextStyle);
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
       List<Map<String, dynamic>> drawCircleResults = [];
-      when(_mockCanvasWrapper.drawCircle(captureAny, captureAny, captureAny))
+      when(mockCanvasWrapper.drawCircle(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         drawCircleResults.add({
           'offset': inv.positionalArguments[0] as Offset,
@@ -436,7 +435,7 @@ void main() {
       });
 
       List<Map<String, dynamic>> drawPathResults = [];
-      when(_mockCanvasWrapper.drawPath(captureAny, captureAny))
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
           .thenAnswer((inv) {
         drawPathResults.add({
           'path': inv.positionalArguments[0] as Path,
@@ -446,7 +445,7 @@ void main() {
         });
       });
 
-      radarChartPainter.drawDataSets(_mockCanvasWrapper, holder);
+      radarChartPainter.drawDataSets(mockCanvasWrapper, holder);
       expect(drawCircleResults.length, 9);
 
       expect(
@@ -542,18 +541,18 @@ void main() {
       final RadarChartPainter radarChartPainter = RadarChartPainter();
       final holder = PaintHolder<RadarChartData>(data, data, 1.0);
 
-      final _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      final _mockUtils = MockUtils();
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
           (realInvocation) =>
               realInvocation.positionalArguments[1] as TextStyle);
-      Utils.changeInstance(_mockUtils);
+      Utils.changeInstance(mockUtils);
 
       List<Map<String, dynamic>> drawCircleResults = [];
-      when(_mockCanvasWrapper.drawCircle(captureAny, captureAny, captureAny))
+      when(mockCanvasWrapper.drawCircle(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         drawCircleResults.add({
           'offset': inv.positionalArguments[0] as Offset,
@@ -563,7 +562,7 @@ void main() {
       });
 
       List<Map<String, dynamic>> drawPathResults = [];
-      when(_mockCanvasWrapper.drawPath(captureAny, captureAny))
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
           .thenAnswer((inv) {
         drawPathResults.add({
           'path': inv.positionalArguments[0] as Path,

--- a/test/chart/radar_chart/radar_chart_painter_test.mocks.dart
+++ b/test/chart/radar_chart/radar_chart_painter_test.mocks.dart
@@ -390,6 +390,10 @@ class MockBuildContext extends _i1.Mock implements _i3.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i3.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i3.DiagnosticsNode describeElement(String? name,
           {_i4.DiagnosticsTreeStyle? style =
               _i4.DiagnosticsTreeStyle.errorProperty}) =>

--- a/test/chart/radar_chart/radar_chart_renderer_test.dart
+++ b/test/chart/radar_chart/radar_chart_renderer_test.dart
@@ -25,22 +25,21 @@ void main() {
 
     const textScale = 4.0;
 
-    MockBuildContext _mockBuildContext = MockBuildContext();
+    MockBuildContext mockBuildContext = MockBuildContext();
     RenderRadarChart renderRadarChart = RenderRadarChart(
-      _mockBuildContext,
+      mockBuildContext,
       data,
       targetData,
       textScale,
     );
 
-    MockRadarChartPainter _mockPainter = MockRadarChartPainter();
-    MockPaintingContext _mockPaintingContext = MockPaintingContext();
-    MockCanvas _mockCanvas = MockCanvas();
-    Size _mockSize = const Size(44, 44);
-    when(_mockPaintingContext.canvas)
-        .thenAnswer((realInvocation) => _mockCanvas);
-    renderRadarChart.mockTestSize = _mockSize;
-    renderRadarChart.painter = _mockPainter;
+    MockRadarChartPainter mockPainter = MockRadarChartPainter();
+    MockPaintingContext mockPaintingContext = MockPaintingContext();
+    MockCanvas mockCanvas = MockCanvas();
+    Size mockSize = const Size(44, 44);
+    when(mockPaintingContext.canvas).thenAnswer((realInvocation) => mockCanvas);
+    renderRadarChart.mockTestSize = mockSize;
+    renderRadarChart.painter = mockPainter;
 
     test('test 1 correct data set', () {
       expect(renderRadarChart.data == data, true);
@@ -53,27 +52,27 @@ void main() {
     });
 
     test('test 2 check paint function', () {
-      renderRadarChart.paint(_mockPaintingContext, const Offset(10, 10));
-      verify(_mockCanvas.save()).called(1);
-      verify(_mockCanvas.translate(10, 10)).called(1);
-      final result = verify(_mockPainter.paint(any, captureAny, captureAny));
+      renderRadarChart.paint(mockPaintingContext, const Offset(10, 10));
+      verify(mockCanvas.save()).called(1);
+      verify(mockCanvas.translate(10, 10)).called(1);
+      final result = verify(mockPainter.paint(any, captureAny, captureAny));
       expect(result.callCount, 1);
 
       final canvasWrapper = result.captured[0] as CanvasWrapper;
       expect(canvasWrapper.size, const Size(44, 44));
-      expect(canvasWrapper.canvas, _mockCanvas);
+      expect(canvasWrapper.canvas, mockCanvas);
 
       final paintHolder = result.captured[1] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);
       expect(paintHolder.textScale, textScale);
 
-      verify(_mockCanvas.restore()).called(1);
+      verify(mockCanvas.restore()).called(1);
     });
 
     test('test 3 check getResponseAtLocation function', () {
       List<Map<String, dynamic>> results = [];
-      when(_mockPainter.handleTouch(captureAny, captureAny, captureAny))
+      when(mockPainter.handleTouch(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
           'local_position': inv.positionalArguments[0] as Offset,
@@ -86,7 +85,7 @@ void main() {
           renderRadarChart.getResponseAtLocation(MockData.offset1);
       expect(touchResponse.touchedSpot, MockData.radarTouchedSpot);
       expect(results[0]['local_position'] as Offset, MockData.offset1);
-      expect(results[0]['size'] as Size, _mockSize);
+      expect(results[0]['size'] as Size, mockSize);
       final paintHolder = results[0]['paint_holder'] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);

--- a/test/chart/radar_chart/radar_chart_renderer_test.mocks.dart
+++ b/test/chart/radar_chart/radar_chart_renderer_test.mocks.dart
@@ -5,15 +5,17 @@
 import 'dart:typed_data' as _i7;
 import 'dart:ui' as _i2;
 
-import 'package:fl_chart/fl_chart.dart' as _i12;
+import 'package:fl_chart/fl_chart.dart' as _i13;
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart'
-    as _i11;
-import 'package:fl_chart/src/chart/radar_chart/radar_chart_painter.dart' as _i9;
-import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i10;
+    as _i12;
+import 'package:fl_chart/src/chart/radar_chart/radar_chart_painter.dart'
+    as _i10;
+import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i11;
 import 'package:flutter/foundation.dart' as _i5;
 import 'package:flutter/material.dart' as _i6;
 import 'package:flutter/rendering.dart' as _i3;
 import 'package:flutter/src/rendering/layer.dart' as _i4;
+import 'package:flutter/src/widgets/notification_listener.dart' as _i9;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:vector_math/vector_math_64.dart' as _i8;
 
@@ -435,6 +437,10 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i9.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i5.DiagnosticsNode describeElement(String? name,
           {_i5.DiagnosticsTreeStyle? style =
               _i5.DiagnosticsTreeStyle.errorProperty}) =>
@@ -464,51 +470,51 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
 /// A class which mocks [RadarChartPainter].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRadarChartPainter extends _i1.Mock implements _i9.RadarChartPainter {
+class MockRadarChartPainter extends _i1.Mock implements _i10.RadarChartPainter {
   MockRadarChartPainter() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set dataSetsPosition(List<_i9.RadarDataSetsPosition>? _dataSetsPosition) =>
+  set dataSetsPosition(List<_i10.RadarDataSetsPosition>? _dataSetsPosition) =>
       super.noSuchMethod(
           Invocation.setter(#dataSetsPosition, _dataSetsPosition),
           returnValueForMissingStub: null);
   @override
-  void paint(_i6.BuildContext? context, _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.RadarChartData>? holder) =>
+  void paint(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.RadarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#paint, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawTicks(_i6.BuildContext? context, _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.RadarChartData>? holder) =>
+  void drawTicks(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.RadarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawTicks, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawGrids(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.RadarChartData>? holder) =>
+  void drawGrids(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.RadarChartData>? holder) =>
       super.noSuchMethod(Invocation.method(#drawGrids, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawTitles(_i6.BuildContext? context, _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.RadarChartData>? holder) =>
+  void drawTitles(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.RadarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawTitles, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawDataSets(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.RadarChartData>? holder) =>
+  void drawDataSets(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.RadarChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawDataSets, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  _i12.RadarTouchedSpot? handleTouch(_i2.Offset? touchedPoint,
-          _i2.Size? viewSize, _i11.PaintHolder<_i12.RadarChartData>? holder) =>
+  _i13.RadarTouchedSpot? handleTouch(_i2.Offset? touchedPoint,
+          _i2.Size? viewSize, _i12.PaintHolder<_i13.RadarChartData>? holder) =>
       (super.noSuchMethod(
               Invocation.method(#handleTouch, [touchedPoint, viewSize, holder]))
-          as _i12.RadarTouchedSpot?);
+          as _i13.RadarTouchedSpot?);
   @override
   double radarCenterY(_i2.Size? size) =>
       (super.noSuchMethod(Invocation.method(#radarCenterY, [size]),
@@ -522,10 +528,10 @@ class MockRadarChartPainter extends _i1.Mock implements _i9.RadarChartPainter {
       (super.noSuchMethod(Invocation.method(#radarRadius, [size]),
           returnValue: 0.0) as double);
   @override
-  List<_i9.RadarDataSetsPosition> calculateDataSetsPosition(
-          _i2.Size? viewSize, _i11.PaintHolder<_i12.RadarChartData>? holder) =>
+  List<_i10.RadarDataSetsPosition> calculateDataSetsPosition(
+          _i2.Size? viewSize, _i12.PaintHolder<_i13.RadarChartData>? holder) =>
       (super.noSuchMethod(
               Invocation.method(#calculateDataSetsPosition, [viewSize, holder]),
-              returnValue: <_i9.RadarDataSetsPosition>[])
-          as List<_i9.RadarDataSetsPosition>);
+              returnValue: <_i10.RadarDataSetsPosition>[])
+          as List<_i10.RadarDataSetsPosition>);
 }

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -30,34 +30,34 @@ void main() {
       final scatterPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenAnswer((realInvocation) => textStyle1);
-      when(_mockUtils.calculateRotationOffset(any, any))
+      when(mockUtils.calculateRotationOffset(any, any))
           .thenAnswer((realInvocation) => Offset.zero);
-      when(_mockUtils.convertRadiusToSigma(any))
+      when(mockUtils.convertRadiusToSigma(any))
           .thenAnswer((realInvocation) => 4.0);
-      when(_mockUtils.getEfficientInterval(any, any))
+      when(mockUtils.getEfficientInterval(any, any))
           .thenAnswer((realInvocation) => 1.0);
-      when(_mockUtils.getBestInitialIntervalValue(any, any, any))
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
           .thenAnswer((realInvocation) => 1.0);
-      when(_mockUtils.normalizeBorderRadius(any, any))
+      when(mockUtils.normalizeBorderRadius(any, any))
           .thenAnswer((realInvocation) => BorderRadius.zero);
-      when(_mockUtils.normalizeBorderSide(any, any)).thenAnswer(
+      when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
           (realInvocation) => const BorderSide(color: MockData.color0));
 
-      final _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterPainter.paint(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawCircle(any, any, any)).called(3);
+      verify(mockCanvasWrapper.drawCircle(any, any, any)).called(3);
       Utils.changeInstance(utilsMainInstance);
     });
   });
@@ -84,25 +84,25 @@ void main() {
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
 
-      MockBuildContext _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenReturn(viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockBuildContext mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenReturn(viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawSpots(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawCircle(const Offset(10, 90), 18, any))
+      verify(mockCanvasWrapper.drawCircle(const Offset(10, 90), 18, any))
           .called(1);
-      verify(_mockCanvasWrapper.drawCircle(const Offset(80, 80), 4, any))
+      verify(mockCanvasWrapper.drawCircle(const Offset(80, 80), 4, any))
           .called(1);
-      verify(_mockCanvasWrapper.drawCircle(const Offset(70, 50), 6, any))
+      verify(mockCanvasWrapper.drawCircle(const Offset(70, 50), 6, any))
           .called(1);
 
-      verifyNever(_mockCanvasWrapper.drawText(any, any));
-      verify(_mockCanvasWrapper.clipRect(any)).called(1);
+      verifyNever(mockCanvasWrapper.drawText(any, any));
+      verify(mockCanvasWrapper.clipRect(any)).called(1);
     });
 
     test('test 2', () {
@@ -126,20 +126,20 @@ void main() {
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
 
-      MockBuildContext _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenReturn(viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockBuildContext mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenReturn(viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawSpots(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verifyNever(_mockCanvasWrapper.drawCircle(any, any, any));
-      verifyNever(_mockCanvasWrapper.clipRect(any));
+      verifyNever(mockCanvasWrapper.drawCircle(any, any, any));
+      verifyNever(mockCanvasWrapper.clipRect(any));
 
-      verifyNever(_mockCanvasWrapper.drawText(any, any));
+      verifyNever(mockCanvasWrapper.drawText(any, any));
     });
 
     test('test 3', () {
@@ -175,38 +175,37 @@ void main() {
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
 
-      MockBuildContext _mockBuildContext = MockBuildContext();
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      when(_mockCanvasWrapper.size).thenReturn(viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockBuildContext mockBuildContext = MockBuildContext();
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenReturn(viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
 
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenReturn(const TextStyle(color: Color(0x00ffffff)));
-      when(_mockUtils.calculateRotationOffset(any, any))
-          .thenReturn(Offset.zero);
+      when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
 
       scatterChartPainter.drawSpots(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawCircle(const Offset(10, 90), 18, any))
+      verify(mockCanvasWrapper.drawCircle(const Offset(10, 90), 18, any))
           .called(1);
-      verify(_mockCanvasWrapper.drawCircle(const Offset(20, 80), 8, any))
+      verify(mockCanvasWrapper.drawCircle(const Offset(20, 80), 8, any))
           .called(1);
-      verify(_mockCanvasWrapper.drawCircle(const Offset(80, 20), 4, any))
+      verify(mockCanvasWrapper.drawCircle(const Offset(80, 20), 4, any))
           .called(1);
-      verify(_mockCanvasWrapper.drawCircle(const Offset(70, 50), 20, any))
+      verify(mockCanvasWrapper.drawCircle(const Offset(70, 50), 20, any))
           .called(1);
-      verify(_mockCanvasWrapper.drawCircle(const Offset(40, 40), 24, any))
+      verify(mockCanvasWrapper.drawCircle(const Offset(40, 40), 24, any))
           .called(1);
 
-      verify(_mockCanvasWrapper.drawText(any, any)).called(4);
+      verify(mockCanvasWrapper.drawText(any, any)).called(4);
 
-      verify(_mockCanvasWrapper.clipRect(any)).called(1);
+      verify(mockCanvasWrapper.clipRect(any)).called(1);
     });
   });
 
@@ -231,23 +230,22 @@ void main() {
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      MockBuildContext _mockBuildContext = MockBuildContext();
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      MockBuildContext mockBuildContext = MockBuildContext();
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenReturn(const TextStyle(color: Color(0x00ffffff)));
-      when(_mockUtils.calculateRotationOffset(any, any))
-          .thenReturn(Offset.zero);
-      when(_mockCanvasWrapper.size).thenReturn(viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
+      when(mockCanvasWrapper.size).thenReturn(viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawTouchTooltips(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verify(_mockCanvasWrapper.drawRotated(
+      verify(mockCanvasWrapper.drawRotated(
               size: anyNamed("size"),
               rotationOffset: anyNamed("rotationOffset"),
               drawOffset: anyNamed("drawOffset"),
@@ -280,24 +278,23 @@ void main() {
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      MockBuildContext _mockBuildContext = MockBuildContext();
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any))
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      MockBuildContext mockBuildContext = MockBuildContext();
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any))
           .thenReturn(const TextStyle(color: Color(0x00ffffff)));
-      when(_mockUtils.calculateRotationOffset(any, any))
-          .thenReturn(Offset.zero);
-      when(_mockCanvasWrapper.size).thenReturn(viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
+      when(mockCanvasWrapper.size).thenReturn(viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawTouchTooltips(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         holder,
       );
 
-      verifyNever(_mockCanvasWrapper.drawRotated());
-      verifyNever(_mockCanvasWrapper.drawRect(any, any));
+      verifyNever(mockCanvasWrapper.drawRotated());
+      verifyNever(mockCanvasWrapper.drawRect(any, any));
     });
   });
 
@@ -342,24 +339,23 @@ void main() {
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      MockBuildContext _mockBuildContext = MockBuildContext();
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle2);
-      when(_mockUtils.calculateRotationOffset(any, any))
-          .thenReturn(Offset.zero);
-      when(_mockCanvasWrapper.size).thenReturn(viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      MockBuildContext mockBuildContext = MockBuildContext();
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle2);
+      when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
+      when(mockCanvasWrapper.size).thenReturn(viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawTouchTooltip(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         (data.touchData as ScatterTouchData).touchTooltipData,
         spot1,
         holder,
       );
 
-      final verificationResult = verify(_mockCanvasWrapper.drawRotated(
+      final verificationResult = verify(mockCanvasWrapper.drawRotated(
           size: anyNamed("size"),
           rotationOffset: Offset.zero,
           drawOffset: anyNamed("drawOffset"),
@@ -372,8 +368,8 @@ void main() {
       verificationResult.called(1);
 
       final captured2 = verifyInOrder([
-        _mockCanvasWrapper.drawRRect(captureAny, captureAny),
-        _mockCanvasWrapper.drawText(captureAny, any),
+        mockCanvasWrapper.drawRRect(captureAny, captureAny),
+        mockCanvasWrapper.drawText(captureAny, any),
       ]).captured;
 
       final RRect rRect = captured2[0][0] as RRect;
@@ -438,24 +434,23 @@ void main() {
 
       final ScatterChartPainter scatterChartPainter = ScatterChartPainter();
       final holder = PaintHolder<ScatterChartData>(data, data, 1.0);
-      MockCanvasWrapper _mockCanvasWrapper = MockCanvasWrapper();
-      MockBuildContext _mockBuildContext = MockBuildContext();
-      MockUtils _mockUtils = MockUtils();
-      Utils.changeInstance(_mockUtils);
-      when(_mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle1);
-      when(_mockUtils.calculateRotationOffset(any, any))
-          .thenReturn(Offset.zero);
-      when(_mockCanvasWrapper.size).thenReturn(viewSize);
-      when(_mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      MockCanvasWrapper mockCanvasWrapper = MockCanvasWrapper();
+      MockBuildContext mockBuildContext = MockBuildContext();
+      MockUtils mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenReturn(textStyle1);
+      when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
+      when(mockCanvasWrapper.size).thenReturn(viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       scatterChartPainter.drawTouchTooltip(
-        _mockBuildContext,
-        _mockCanvasWrapper,
+        mockBuildContext,
+        mockCanvasWrapper,
         (data.touchData as ScatterTouchData).touchTooltipData,
         spot1,
         holder,
       );
 
-      final verificationResult = verify(_mockCanvasWrapper.drawRotated(
+      final verificationResult = verify(mockCanvasWrapper.drawRotated(
           size: anyNamed("size"),
           rotationOffset: Offset.zero,
           drawOffset: anyNamed("drawOffset"),
@@ -468,8 +463,8 @@ void main() {
       verificationResult.called(1);
 
       final captured2 = verifyInOrder([
-        _mockCanvasWrapper.drawRRect(captureAny, captureAny),
-        _mockCanvasWrapper.drawText(captureAny, any),
+        mockCanvasWrapper.drawRRect(captureAny, captureAny),
+        mockCanvasWrapper.drawText(captureAny, any),
       ]).captured;
 
       final RRect rRect = captured2[0][0] as RRect;

--- a/test/chart/scatter_chart/scatter_chart_painter_test.mocks.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.mocks.dart
@@ -390,6 +390,10 @@ class MockBuildContext extends _i1.Mock implements _i3.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i3.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i3.DiagnosticsNode describeElement(String? name,
           {_i4.DiagnosticsTreeStyle? style =
               _i4.DiagnosticsTreeStyle.errorProperty}) =>

--- a/test/chart/scatter_chart/scatter_chart_renderer_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_renderer_test.dart
@@ -21,22 +21,21 @@ void main() {
 
     const textScale = 4.0;
 
-    MockBuildContext _mockBuildContext = MockBuildContext();
+    MockBuildContext mockBuildContext = MockBuildContext();
     RenderScatterChart renderScatterChart = RenderScatterChart(
-      _mockBuildContext,
+      mockBuildContext,
       data,
       targetData,
       textScale,
     );
 
-    MockScatterChartPainter _mockPainter = MockScatterChartPainter();
-    MockPaintingContext _mockPaintingContext = MockPaintingContext();
-    MockCanvas _mockCanvas = MockCanvas();
-    Size _mockSize = const Size(44, 44);
-    when(_mockPaintingContext.canvas)
-        .thenAnswer((realInvocation) => _mockCanvas);
-    renderScatterChart.mockTestSize = _mockSize;
-    renderScatterChart.painter = _mockPainter;
+    MockScatterChartPainter mockPainter = MockScatterChartPainter();
+    MockPaintingContext mockPaintingContext = MockPaintingContext();
+    MockCanvas mockCanvas = MockCanvas();
+    Size mockSize = const Size(44, 44);
+    when(mockPaintingContext.canvas).thenAnswer((realInvocation) => mockCanvas);
+    renderScatterChart.mockTestSize = mockSize;
+    renderScatterChart.painter = mockPainter;
 
     test('test 1 correct data set', () {
       expect(renderScatterChart.data == data, true);
@@ -49,27 +48,27 @@ void main() {
     });
 
     test('test 2 check paint function', () {
-      renderScatterChart.paint(_mockPaintingContext, const Offset(10, 10));
-      verify(_mockCanvas.save()).called(1);
-      verify(_mockCanvas.translate(10, 10)).called(1);
-      final result = verify(_mockPainter.paint(any, captureAny, captureAny));
+      renderScatterChart.paint(mockPaintingContext, const Offset(10, 10));
+      verify(mockCanvas.save()).called(1);
+      verify(mockCanvas.translate(10, 10)).called(1);
+      final result = verify(mockPainter.paint(any, captureAny, captureAny));
       expect(result.callCount, 1);
 
       final canvasWrapper = result.captured[0] as CanvasWrapper;
       expect(canvasWrapper.size, const Size(44, 44));
-      expect(canvasWrapper.canvas, _mockCanvas);
+      expect(canvasWrapper.canvas, mockCanvas);
 
       final paintHolder = result.captured[1] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);
       expect(paintHolder.textScale, textScale);
 
-      verify(_mockCanvas.restore()).called(1);
+      verify(mockCanvas.restore()).called(1);
     });
 
     test('test 3 check getResponseAtLocation function', () {
       List<Map<String, dynamic>> results = [];
-      when(_mockPainter.handleTouch(captureAny, captureAny, captureAny))
+      when(mockPainter.handleTouch(captureAny, captureAny, captureAny))
           .thenAnswer((inv) {
         results.add({
           'local_position': inv.positionalArguments[0] as Offset,
@@ -82,7 +81,7 @@ void main() {
           renderScatterChart.getResponseAtLocation(MockData.offset1);
       expect(touchResponse.touchedSpot, MockData.scatterTouchedSpot);
       expect(results[0]['local_position'] as Offset, MockData.offset1);
-      expect(results[0]['size'] as Size, _mockSize);
+      expect(results[0]['size'] as Size, mockSize);
       final paintHolder = results[0]['paint_holder'] as PaintHolder;
       expect(paintHolder.data, data);
       expect(paintHolder.targetData, targetData);

--- a/test/chart/scatter_chart/scatter_chart_renderer_test.mocks.dart
+++ b/test/chart/scatter_chart/scatter_chart_renderer_test.mocks.dart
@@ -5,16 +5,17 @@
 import 'dart:typed_data' as _i7;
 import 'dart:ui' as _i2;
 
-import 'package:fl_chart/fl_chart.dart' as _i12;
+import 'package:fl_chart/fl_chart.dart' as _i13;
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart'
-    as _i11;
+    as _i12;
 import 'package:fl_chart/src/chart/scatter_chart/scatter_chart_painter.dart'
-    as _i9;
-import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i10;
+    as _i10;
+import 'package:fl_chart/src/utils/canvas_wrapper.dart' as _i11;
 import 'package:flutter/foundation.dart' as _i5;
 import 'package:flutter/material.dart' as _i6;
 import 'package:flutter/rendering.dart' as _i3;
 import 'package:flutter/src/rendering/layer.dart' as _i4;
+import 'package:flutter/src/widgets/notification_listener.dart' as _i9;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:vector_math/vector_math_64.dart' as _i8;
 
@@ -436,6 +437,10 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i9.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i5.DiagnosticsNode describeElement(String? name,
           {_i5.DiagnosticsTreeStyle? style =
               _i5.DiagnosticsTreeStyle.errorProperty}) =>
@@ -466,28 +471,28 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockScatterChartPainter extends _i1.Mock
-    implements _i9.ScatterChartPainter {
+    implements _i10.ScatterChartPainter {
   MockScatterChartPainter() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void paint(_i6.BuildContext? context, _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+  void paint(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#paint, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawSpots(_i6.BuildContext? context, _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+  void drawSpots(_i6.BuildContext? context, _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawSpots, [context, canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
   void drawTouchTooltips(
           _i6.BuildContext? context,
-          _i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(
               #drawTouchTooltips, [context, canvasWrapper, holder]),
@@ -495,48 +500,48 @@ class MockScatterChartPainter extends _i1.Mock
   @override
   void drawTouchTooltip(
           _i6.BuildContext? context,
-          _i10.CanvasWrapper? canvasWrapper,
-          _i12.ScatterTouchTooltipData? tooltipData,
-          _i12.ScatterSpot? showOnSpot,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+          _i11.CanvasWrapper? canvasWrapper,
+          _i13.ScatterTouchTooltipData? tooltipData,
+          _i13.ScatterSpot? showOnSpot,
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawTouchTooltip,
               [context, canvasWrapper, tooltipData, showOnSpot, holder]),
           returnValueForMissingStub: null);
   @override
-  _i12.ScatterTouchedSpot? handleTouch(
+  _i13.ScatterTouchedSpot? handleTouch(
           _i2.Offset? localPosition,
           _i2.Size? viewSize,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       (super.noSuchMethod(Invocation.method(
               #handleTouch, [localPosition, viewSize, holder]))
-          as _i12.ScatterTouchedSpot?);
+          as _i13.ScatterTouchedSpot?);
   @override
-  void drawGrid(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+  void drawGrid(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       super.noSuchMethod(Invocation.method(#drawGrid, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawBackground(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+  void drawBackground(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawBackground, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
-  void drawRangeAnnotation(_i10.CanvasWrapper? canvasWrapper,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+  void drawRangeAnnotation(_i11.CanvasWrapper? canvasWrapper,
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       super.noSuchMethod(
           Invocation.method(#drawRangeAnnotation, [canvasWrapper, holder]),
           returnValueForMissingStub: null);
   @override
   double getPixelX(double? spotX, _i2.Size? viewSize,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#getPixelX, [spotX, viewSize, holder]),
           returnValue: 0.0) as double);
   @override
   double getPixelY(double? spotY, _i2.Size? viewSize,
-          _i11.PaintHolder<_i12.ScatterChartData>? holder) =>
+          _i12.PaintHolder<_i13.ScatterChartData>? holder) =>
       (super.noSuchMethod(
           Invocation.method(#getPixelY, [spotY, viewSize, holder]),
           returnValue: 0.0) as double);

--- a/test/utils/canvas_wrapper_test.dart
+++ b/test/utils/canvas_wrapper_test.dart
@@ -11,67 +11,67 @@ import 'canvas_wrapper_test.mocks.dart';
 
 @GenerateMocks([Canvas, FlDotPainter, Utils])
 void main() {
-  MockCanvas _mockCanvas = MockCanvas();
-  CanvasWrapper canvasWrapper = CanvasWrapper(_mockCanvas, MockData.size1);
+  MockCanvas mockCanvas = MockCanvas();
+  CanvasWrapper canvasWrapper = CanvasWrapper(mockCanvas, MockData.size1);
 
   test('test drawRRect', () {
     canvasWrapper.drawRRect(MockData.rRect1, MockData.paint1);
-    verify(_mockCanvas.drawRRect(MockData.rRect1, MockData.paint1)).called(1);
+    verify(mockCanvas.drawRRect(MockData.rRect1, MockData.paint1)).called(1);
   });
 
   test('test save', () {
     canvasWrapper.save();
-    verify(_mockCanvas.save()).called(1);
+    verify(mockCanvas.save()).called(1);
   });
 
   test('test restore', () {
     canvasWrapper.restore();
-    verify(_mockCanvas.restore()).called(1);
+    verify(mockCanvas.restore()).called(1);
   });
 
   test('test clipRect', () {
     canvasWrapper.clipRect(MockData.rect1);
-    verify(_mockCanvas.clipRect(MockData.rect1)).called(1);
+    verify(mockCanvas.clipRect(MockData.rect1)).called(1);
   });
 
   test('test translate', () {
     canvasWrapper.translate(11, 232);
-    verify(_mockCanvas.translate(11, 232)).called(1);
+    verify(mockCanvas.translate(11, 232)).called(1);
   });
 
   test('test rotate', () {
     canvasWrapper.rotate(12);
-    verify(_mockCanvas.rotate(12)).called(1);
+    verify(mockCanvas.rotate(12)).called(1);
   });
 
   test('test drawPath', () {
     canvasWrapper.drawPath(MockData.path1, MockData.paint1);
-    verify(_mockCanvas.drawPath(MockData.path1, MockData.paint1)).called(1);
+    verify(mockCanvas.drawPath(MockData.path1, MockData.paint1)).called(1);
   });
 
   test('test saveLayer', () {
     canvasWrapper.saveLayer(MockData.rect1, MockData.paint1);
-    verify(_mockCanvas.saveLayer(MockData.rect1, MockData.paint1)).called(1);
+    verify(mockCanvas.saveLayer(MockData.rect1, MockData.paint1)).called(1);
   });
 
   test('test drawPicture', () {
     canvasWrapper.drawPicture(MockData.picture1());
-    verify(_mockCanvas.drawPicture(MockData.picture1())).called(1);
+    verify(mockCanvas.drawPicture(MockData.picture1())).called(1);
   });
 
   test('test clipPath', () {
     canvasWrapper.clipPath(MockData.path1);
-    verify(_mockCanvas.clipPath(MockData.path1)).called(1);
+    verify(mockCanvas.clipPath(MockData.path1)).called(1);
   });
 
   test('test drawRect', () {
     canvasWrapper.drawRect(MockData.rect1, MockData.paint1);
-    verify(_mockCanvas.drawRect(MockData.rect1, MockData.paint1)).called(1);
+    verify(mockCanvas.drawRect(MockData.rect1, MockData.paint1)).called(1);
   });
 
   test('test drawLine', () {
     canvasWrapper.drawLine(MockData.offset1, MockData.offset2, MockData.paint1);
-    verify(_mockCanvas.drawLine(
+    verify(mockCanvas.drawLine(
       MockData.offset1,
       MockData.offset2,
       MockData.paint1,
@@ -80,27 +80,27 @@ void main() {
 
   test('test drawCircle', () {
     canvasWrapper.drawCircle(MockData.offset1, 12, MockData.paint1);
-    verify(_mockCanvas.drawCircle(MockData.offset1, 12, MockData.paint1))
+    verify(mockCanvas.drawCircle(MockData.offset1, 12, MockData.paint1))
         .called(1);
   });
 
   test('test drawArc', () {
     canvasWrapper.drawArc(MockData.rect1, 12, 22, false, MockData.paint1);
-    verify(_mockCanvas.drawArc(MockData.rect1, 12, 22, false, MockData.paint1))
+    verify(mockCanvas.drawArc(MockData.rect1, 12, 22, false, MockData.paint1))
         .called(1);
   });
 
   test('test drawDot', () {
     MockFlDotPainter painter = MockFlDotPainter();
     canvasWrapper.drawDot(painter, MockData.lineBarSpot1, MockData.offset1);
-    verify(painter.draw(_mockCanvas, MockData.lineBarSpot1, MockData.offset1))
+    verify(painter.draw(mockCanvas, MockData.lineBarSpot1, MockData.offset1))
         .called(1);
   });
 
   test('test drawRotated', () {
-    final _mockUtils = MockUtils();
-    when(_mockUtils.radians(any)).thenAnswer((realInvocation) => 12);
-    Utils.changeInstance(_mockUtils);
+    final mockUtils = MockUtils();
+    when(mockUtils.radians(any)).thenAnswer((realInvocation) => 12);
+    Utils.changeInstance(mockUtils);
 
     var calledCallback = false;
     void callback() {
@@ -114,11 +114,11 @@ void main() {
       angle: 12,
       drawCallback: callback,
     );
-    verify(_mockCanvas.save()).called(1);
-    verify(_mockCanvas.translate(123, 123)).called(1);
-    verify(_mockCanvas.rotate(12)).called(1);
-    verify(_mockCanvas.translate(-122, -122)).called(1);
+    verify(mockCanvas.save()).called(1);
+    verify(mockCanvas.translate(123, 123)).called(1);
+    verify(mockCanvas.rotate(12)).called(1);
+    verify(mockCanvas.translate(-122, -122)).called(1);
     expect(calledCallback, true);
-    verify(_mockCanvas.restore()).called(1);
+    verify(mockCanvas.restore()).called(1);
   });
 }

--- a/test/utils/utils_test.dart
+++ b/test/utils/utils_test.dart
@@ -13,15 +13,15 @@ void main() {
   const tolerance = 0.001;
 
   test('changeInstance', () {
-    Utils _mockUtils = MockUtils();
+    Utils mockUtils = MockUtils();
     Utils realUtils = Utils();
     expect(Utils(), realUtils);
-    Utils.changeInstance(_mockUtils);
-    expect(Utils(), _mockUtils);
+    Utils.changeInstance(mockUtils);
+    expect(Utils(), mockUtils);
     expect(Utils() != realUtils, true);
     Utils.changeInstance(realUtils);
     expect(Utils(), realUtils);
-    expect(Utils() != _mockUtils, true);
+    expect(Utils() != mockUtils, true);
   });
 
   test('test degrees to radians', () {
@@ -216,15 +216,15 @@ void main() {
 
   group('test getThemeAwareTextStyle', () {
     test('test 1', () {
-      final _mockBuildContext = MockBuildContext();
-      const _defaultTextStyle = DefaultTextStyle.fallback();
+      final mockBuildContext = MockBuildContext();
+      const defaultTextStyle = DefaultTextStyle.fallback();
 
       var callCount = 0;
-      when(_mockBuildContext.dependOnInheritedWidgetOfExactType())
+      when(mockBuildContext.dependOnInheritedWidgetOfExactType())
           .thenAnswer((realInvocation) {
         if (callCount == 0) {
           callCount++;
-          return _defaultTextStyle;
+          return defaultTextStyle;
         } else {
           return MediaQuery(
             data: const MediaQueryData(boldText: false),
@@ -233,21 +233,21 @@ void main() {
         }
       });
       expect(
-        Utils().getThemeAwareTextStyle(_mockBuildContext, null),
-        _defaultTextStyle.style,
+        Utils().getThemeAwareTextStyle(mockBuildContext, null),
+        defaultTextStyle.style,
       );
     });
 
     test('test 2', () {
-      final _mockBuildContext = MockBuildContext();
-      const _defaultTextStyle = DefaultTextStyle.fallback();
+      final mockBuildContext = MockBuildContext();
+      const defaultTextStyle = DefaultTextStyle.fallback();
 
       var callCount = 0;
-      when(_mockBuildContext.dependOnInheritedWidgetOfExactType())
+      when(mockBuildContext.dependOnInheritedWidgetOfExactType())
           .thenAnswer((realInvocation) {
         if (callCount == 0) {
           callCount++;
-          return _defaultTextStyle;
+          return defaultTextStyle;
         } else {
           return MediaQuery(
             data: const MediaQueryData(boldText: true),
@@ -258,7 +258,7 @@ void main() {
       expect(
         Utils()
             .getThemeAwareTextStyle(
-              _mockBuildContext,
+              mockBuildContext,
               MockData.textStyle1,
             )
             .fontWeight,

--- a/test/utils/utils_test.mocks.dart
+++ b/test/utils/utils_test.mocks.dart
@@ -157,6 +157,10 @@ class MockBuildContext extends _i1.Mock implements _i3.BuildContext {
       super.noSuchMethod(Invocation.method(#visitChildElements, [visitor]),
           returnValueForMissingStub: null);
   @override
+  void dispatchNotification(_i3.Notification? notification) => super
+      .noSuchMethod(Invocation.method(#dispatchNotification, [notification]),
+          returnValueForMissingStub: null);
+  @override
   _i3.DiagnosticsNode describeElement(String? name,
           {_i4.DiagnosticsTreeStyle? style =
               _i4.DiagnosticsTreeStyle.errorProperty}) =>


### PR DESCRIPTION
## 0.50.5
* **IMPROVEMENT** Fix test coverage problem again :/

## 0.50.4
* **IMPROVEMENT** Fix test coverage problem 

## 0.50.3
* **IMPROVEMENT** Fix order of drawing lineChart bar indicator problem, #198.
* **FEATURE** Add `isStrokeJoinRound` property in [LineChartBarData](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md#linechartbardata).
* **IMPROVEMENT** Upgrade to Flutter 3, #997.
* **FEATURE** Add `chartRendererKey` property to the [LineChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/line_chart.md), [BarChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/bar_chart.md), and [ScatterChart](https://github.com/imaNNeoFighT/fl_chart/blob/master/repo_files/documentations/scatter_chart.md). We pass it directly to our chart renderers that are responsible to render the chart itself (without anything around it like titles), #987.
