### PR TITLE
Improvement/titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## newVersion
+* **FEATURE** Add `SideTitleWidget` to help you use it in [SideTitles.getTitlesWidget]. It's a wrapper around your widget. It keeps your provided `child` widget close to the chart. It has `angle` and `space` properties to handle margin and rotation. There is a `axisSide` property that you should fill, it has provided to you in the MetaData object. Check the below sample:
+```dart
+getTitlesWidget: (double value, TitleMeta meta) {
+  return SideTitleWidget(
+    axisSide: meta.axisSide,
+    space: 8.0,
+    angle: 0.0,
+    child: const Text("This is your widget"),
+  );
+},
+```
+
 ## 0.50.6
 * **IMPROVEMENT** Fix a backward compatibility issue with Flutter 3.0, #1016
 

--- a/example/lib/bar_chart/samples/bar_chart_sample1.dart
+++ b/example/lib/bar_chart/samples/bar_chart_sample1.dart
@@ -280,7 +280,11 @@ class BarChartSample1State extends State<BarChartSample1> {
         text = const Text('', style: style);
         break;
     }
-    return Padding(padding: const EdgeInsets.only(top: 16), child: text);
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 16,
+      child: text,
+    );
   }
 
   BarChartData randomData() {

--- a/example/lib/bar_chart/samples/bar_chart_sample2.dart
+++ b/example/lib/bar_chart/samples/bar_chart_sample2.dart
@@ -193,7 +193,11 @@ class BarChartSample2State extends State<BarChartSample2> {
     } else {
       return Container();
     }
-    return Text(text, style: style);
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 0,
+      child: Text(text, style: style),
+    );
   }
 
   Widget bottomTitles(double value, TitleMeta meta) {
@@ -253,7 +257,11 @@ class BarChartSample2State extends State<BarChartSample2> {
         );
         break;
     }
-    return Padding(padding: const EdgeInsets.only(top: 20), child: text);
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 16,
+      child: text,
+    );
   }
 
   BarChartGroupData makeGroupData(int x, double y1, double y2) {

--- a/example/lib/bar_chart/samples/bar_chart_sample3.dart
+++ b/example/lib/bar_chart/samples/bar_chart_sample3.dart
@@ -75,7 +75,11 @@ class _BarChart extends StatelessWidget {
         text = '';
         break;
     }
-    return Center(child: Text(text, style: style));
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 4.0,
+      child: Text(text, style: style),
+    );
   }
 
   FlTitlesData get titlesData => FlTitlesData(

--- a/example/lib/bar_chart/samples/bar_chart_sample4.dart
+++ b/example/lib/bar_chart/samples/bar_chart_sample4.dart
@@ -36,7 +36,10 @@ class BarChartSample4State extends State<BarChartSample4> {
         text = '';
         break;
     }
-    return Center(child: Text(text, style: style));
+    return SideTitleWidget(
+      child: Text(text, style: style),
+      axisSide: meta.axisSide,
+    );
   }
 
   Widget leftTitles(double value, TitleMeta meta) {
@@ -49,9 +52,12 @@ class BarChartSample4State extends State<BarChartSample4> {
       ),
       fontSize: 10,
     );
-    return Padding(
-      child: Text(meta.formattedValue, style: style),
-      padding: const EdgeInsets.only(left: 8),
+    return SideTitleWidget(
+      child: Text(
+        meta.formattedValue,
+        style: style,
+      ),
+      axisSide: meta.axisSide,
     );
   }
 

--- a/example/lib/bar_chart/samples/bar_chart_sample5.dart
+++ b/example/lib/bar_chart/samples/bar_chart_sample5.dart
@@ -57,7 +57,10 @@ class BarChartSample5State extends State<BarChartSample5> {
         text = '';
         break;
     }
-    return Center(child: Text(text, style: style));
+    return SideTitleWidget(
+      child: Text(text, style: style),
+      axisSide: meta.axisSide,
+    );
   }
 
   Widget topTitles(double value, TitleMeta meta) {
@@ -88,7 +91,10 @@ class BarChartSample5State extends State<BarChartSample5> {
       default:
         return Container();
     }
-    return Center(child: Text(text, style: style));
+    return SideTitleWidget(
+      child: Text(text, style: style),
+      axisSide: meta.axisSide,
+    );
   }
 
   Widget leftTitles(double value, TitleMeta meta) {
@@ -99,8 +105,10 @@ class BarChartSample5State extends State<BarChartSample5> {
     } else {
       text = '${value.toInt()}0k';
     }
-    return Transform.rotate(
+    return SideTitleWidget(
       angle: AppUtils().degreeToRadian(value < 0 ? -45 : 45),
+      axisSide: meta.axisSide,
+      space: 4.0,
       child: Text(
         text,
         style: style,
@@ -117,8 +125,10 @@ class BarChartSample5State extends State<BarChartSample5> {
     } else {
       text = '${value.toInt()}0k';
     }
-    return Transform.rotate(
+    return SideTitleWidget(
       angle: AppUtils().degreeToRadian(90),
+      axisSide: meta.axisSide,
+      space: 0,
       child: Text(
         text,
         style: style,

--- a/example/lib/bar_chart/samples/bar_chart_sample6.dart
+++ b/example/lib/bar_chart/samples/bar_chart_sample6.dart
@@ -85,11 +85,9 @@ class BarChartSample6 extends StatelessWidget {
       default:
         text = "";
     }
-    return Padding(
+    return SideTitleWidget(
       child: Text(text, style: style),
-      padding: const EdgeInsets.only(
-        top: 4,
-      ),
+      axisSide: meta.axisSide,
     );
   }
 

--- a/example/lib/bar_chart/samples/bar_chart_sample7.dart
+++ b/example/lib/bar_chart/samples/bar_chart_sample7.dart
@@ -94,8 +94,8 @@ class _BarChartSample7State extends State<BarChartSample7> {
                         reservedSize: 36,
                         getTitlesWidget: (value, meta) {
                           final index = value.toInt();
-                          return Padding(
-                            padding: const EdgeInsets.only(top: 8.0),
+                          return SideTitleWidget(
+                            axisSide: meta.axisSide,
                             child: _IconWidget(
                               color: BarChartSample7.dataList[index].color,
                               isSelected: touchedGroupIndex == index,

--- a/example/lib/line_chart/line_chart_page.dart
+++ b/example/lib/line_chart/line_chart_page.dart
@@ -22,11 +22,12 @@ class LineChartPage extends StatelessWidget {
               child: Text(
                 'Line Chart',
                 style: TextStyle(
-                    color: Color(
-                      0xff6f6f97,
-                    ),
-                    fontSize: 32,
-                    fontWeight: FontWeight.bold),
+                  color: Color(
+                    0xff6f6f97,
+                  ),
+                  fontSize: 32,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
           ),

--- a/example/lib/line_chart/samples/line_chart_sample1.dart
+++ b/example/lib/line_chart/samples/line_chart_sample1.dart
@@ -150,7 +150,11 @@ class _LineChart extends StatelessWidget {
         break;
     }
 
-    return Padding(child: text, padding: const EdgeInsets.only(top: 10.0));
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 10,
+      child: text,
+    );
   }
 
   SideTitles get bottomTitles => SideTitles(

--- a/example/lib/line_chart/samples/line_chart_sample2.dart
+++ b/example/lib/line_chart/samples/line_chart_sample2.dart
@@ -81,7 +81,11 @@ class _LineChartSample2State extends State<LineChartSample2> {
         break;
     }
 
-    return Padding(child: text, padding: const EdgeInsets.only(top: 8.0));
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 8.0,
+      child: text,
+    );
   }
 
   Widget leftTitleWidgets(double value, TitleMeta meta) {

--- a/example/lib/line_chart/samples/line_chart_sample3.dart
+++ b/example/lib/line_chart/samples/line_chart_sample3.dart
@@ -41,9 +41,10 @@ class _LineChartSample3State extends State<LineChartSample3> {
         return Container();
     }
 
-    return Padding(
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 6,
       child: Text(text, style: style, textAlign: TextAlign.center),
-      padding: const EdgeInsets.only(right: 6),
     );
   }
 
@@ -54,7 +55,11 @@ class _LineChartSample3State extends State<LineChartSample3> {
       fontWeight: FontWeight.bold,
     );
 
-    return Text(widget.weekDays[value.toInt()], style: style);
+    return SideTitleWidget(
+      space: 4,
+      child: Text(widget.weekDays[value.toInt()], style: style),
+      axisSide: meta.axisSide,
+    );
   }
 
   @override

--- a/example/lib/line_chart/samples/line_chart_sample4.dart
+++ b/example/lib/line_chart/samples/line_chart_sample4.dart
@@ -47,15 +47,19 @@ class LineChartSample4 extends StatelessWidget {
         return Container();
     }
 
-    return Padding(
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 4,
       child: Text(text, style: _dateTextStyle),
-      padding: const EdgeInsets.only(top: 4),
     );
   }
 
   Widget leftTitleWidgets(double value, TitleMeta meta) {
     const style = TextStyle(color: Colors.black, fontSize: 12.0);
-    return Text('\$ ${value + 0.5}', style: style);
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      child: Text('\$ ${value + 0.5}', style: style),
+    );
   }
 
   static const _dateTextStyle = TextStyle(

--- a/example/lib/line_chart/samples/line_chart_sample5.dart
+++ b/example/lib/line_chart/samples/line_chart_sample5.dart
@@ -49,9 +49,9 @@ class LineChartSample5 extends StatelessWidget {
         return Container();
     }
 
-    return Padding(
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
       child: Text(text, style: style),
-      padding: const EdgeInsets.only(top: 4),
     );
   }
 

--- a/example/lib/line_chart/samples/line_chart_sample6.dart
+++ b/example/lib/line_chart/samples/line_chart_sample6.dart
@@ -88,7 +88,10 @@ class LineChartSample6 extends StatelessWidget {
       fontWeight: FontWeight.bold,
       color: Colors.black,
     );
-    return Center(child: Text(value.toInt().toString(), style: style));
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      child: Text(value.toInt().toString(), style: style),
+    );
   }
 
   @override

--- a/example/lib/line_chart/samples/line_chart_sample7.dart
+++ b/example/lib/line_chart/samples/line_chart_sample7.dart
@@ -52,16 +52,23 @@ class LineChartSample7 extends StatelessWidget {
         return Container();
     }
 
-    return Padding(
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 4,
       child: Text(text, style: style),
-      padding: const EdgeInsets.only(top: 4),
     );
   }
 
   Widget leftTitleWidgets(double value, TitleMeta meta) {
     const style = TextStyle(fontSize: 10);
 
-    return Text('\$ ${value + 0.5}', style: style);
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      child: Text(
+        '\$ ${value + 0.5}',
+        style: style,
+      ),
+    );
   }
 
   @override

--- a/example/lib/line_chart/samples/line_chart_sample8.dart
+++ b/example/lib/line_chart/samples/line_chart_sample8.dart
@@ -67,8 +67,8 @@ class _LineChartSample8State extends State<LineChartSample8> {
 
   Widget bottomTitleWidgets(double value, TitleMeta meta) {
     const style = TextStyle(color: Colors.black87, fontSize: 10);
-    return Padding(
-      padding: const EdgeInsets.only(top: 8.0),
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
       child: Text(meta.formattedValue, style: style),
     );
   }
@@ -96,8 +96,8 @@ class _LineChartSample8State extends State<LineChartSample8> {
       default:
         throw StateError("Invalid");
     }
-    return Padding(
-      padding: const EdgeInsets.only(right: 8.0),
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
       child: Icon(
         icon,
         color: color,

--- a/example/lib/line_chart/samples/line_chart_sample9.dart
+++ b/example/lib/line_chart/samples/line_chart_sample9.dart
@@ -16,8 +16,9 @@ class LineChartSample9 extends StatelessWidget {
       fontWeight: FontWeight.bold,
       fontSize: 18,
     );
-    return Padding(
-      padding: const EdgeInsets.only(top: 16.0),
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 16,
       child: Text(meta.formattedValue, style: style),
     );
   }
@@ -28,8 +29,9 @@ class LineChartSample9 extends StatelessWidget {
       fontWeight: FontWeight.bold,
       fontSize: 18,
     );
-    return Padding(
-      padding: const EdgeInsets.only(right: 16.0),
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      space: 16,
       child: Text(meta.formattedValue, style: style),
     );
   }

--- a/lib/fl_chart.dart
+++ b/lib/fl_chart.dart
@@ -3,6 +3,7 @@ library fl_chart;
 export 'src/chart/bar_chart/bar_chart.dart';
 export 'src/chart/bar_chart/bar_chart_data.dart';
 export 'src/chart/base/axis_chart/axis_chart_data.dart';
+export 'src/chart/base/axis_chart/axis_chart_widgets.dart';
 export 'src/chart/base/base_chart/base_chart_data.dart';
 export 'src/chart/base/base_chart/fl_touch_event.dart';
 export 'src/chart/line_chart/line_chart.dart';

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -133,6 +133,7 @@ class SideTitles with EquatableMixin {
   final bool showTitles;
 
   /// You can override it to pass your custom widget to show in each axis value
+  /// We recommend you to use [SideTitleWidget].
   final GetTitleWidgetFunction getTitlesWidget;
 
   /// It determines the maximum space that your titles need,

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -8,6 +8,8 @@ import 'package:fl_chart/src/chart/base/base_chart/base_chart_data.dart';
 import 'package:fl_chart/src/utils/lerp.dart';
 import 'package:flutter/material.dart';
 
+import 'axis_chart_widgets.dart';
+
 /// This is the base class for axis base charts data
 /// that contains a [FlGridData] that holds data for showing grid lines,
 /// also we have [minX], [maxX], [minY], [maxY] values
@@ -78,6 +80,51 @@ abstract class AxisChartData extends BaseChartData with EquatableMixin {
         borderData,
         touchData,
       ];
+}
+
+/// Represents a side of the chart
+enum AxisSide { left, top, right, bottom }
+
+/// Contains meta information about the drawing title.
+class TitleMeta {
+  /// min axis value
+  final double min;
+
+  /// max axis value
+  final double max;
+
+  /// The interval that applied to this drawing title
+  final double appliedInterval;
+
+  /// Reference of [SideTitles] object.
+  final SideTitles sideTitles;
+
+  /// Formatted value that is suitable to show, for example 100, 2k, 5m, ...
+  final String formattedValue;
+
+  /// Determines the axis side of titles (left, top, right, bottom)
+  final AxisSide axisSide;
+
+  TitleMeta({
+    required this.min,
+    required this.max,
+    required this.appliedInterval,
+    required this.sideTitles,
+    required this.formattedValue,
+    required this.axisSide,
+  });
+}
+
+/// It gives you the axis value and gets a String value based on it.
+typedef GetTitleWidgetFunction = Widget Function(double value, TitleMeta meta);
+
+/// The default [SideTitles.getTitlesWidget] function.
+///
+/// formats the axis number to a shorter string using [formatNumber].
+Widget defaultGetTitle(double value, TitleMeta meta) {
+  return Text(
+    meta.formattedValue,
+  );
 }
 
 /// Holds data for showing label values on axis numbers

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -256,28 +256,28 @@ class FlTitlesData with EquatableMixin {
         leftTitles = leftTitles ??
             AxisTitles(
               sideTitles: SideTitles(
-                reservedSize: 40,
+                reservedSize: 44,
                 showTitles: true,
               ),
             ),
         topTitles = topTitles ??
             AxisTitles(
               sideTitles: SideTitles(
-                reservedSize: 6,
+                reservedSize: 30,
                 showTitles: true,
               ),
             ),
         rightTitles = rightTitles ??
             AxisTitles(
               sideTitles: SideTitles(
-                reservedSize: 40,
+                reservedSize: 44,
                 showTitles: true,
               ),
             ),
         bottomTitles = bottomTitles ??
             AxisTitles(
               sideTitles: SideTitles(
-                reservedSize: 6,
+                reservedSize: 30,
                 showTitles: true,
               ),
             );

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -4,11 +4,8 @@ import 'dart:ui';
 import 'package:equatable/equatable.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_painter.dart';
-import 'package:fl_chart/src/chart/base/base_chart/base_chart_data.dart';
 import 'package:fl_chart/src/utils/lerp.dart';
 import 'package:flutter/material.dart';
-
-import 'axis_chart_widgets.dart';
 
 /// This is the base class for axis base charts data
 /// that contains a [FlGridData] that holds data for showing grid lines,

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -122,8 +122,11 @@ typedef GetTitleWidgetFunction = Widget Function(double value, TitleMeta meta);
 ///
 /// formats the axis number to a shorter string using [formatNumber].
 Widget defaultGetTitle(double value, TitleMeta meta) {
-  return Text(
-    meta.formattedValue,
+  return SideTitleWidget(
+    axisSide: meta.axisSide,
+    child: Text(
+      meta.formattedValue,
+    ),
   );
 }
 

--- a/lib/src/chart/base/axis_chart/axis_chart_scaffold_widget.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_scaffold_widget.dart
@@ -1,7 +1,7 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/extensions/fl_titles_data_extension.dart';
 import 'package:flutter/material.dart';
 
-import 'axis_chart_data.dart';
 import 'side_titles/side_titles_widget.dart';
 
 class AxisChartScaffoldWidget extends StatelessWidget {
@@ -64,7 +64,7 @@ class AxisChartScaffoldWidget extends StatelessWidget {
       widgets.insert(
         insertIndex(data.titlesData.leftTitles.drawBelowEverything),
         SideTitlesWidget(
-          side: TitlesSide.left,
+          side: AxisSide.left,
           axisChartData: data,
           parentSize: constraints.biggest,
         ),
@@ -75,7 +75,7 @@ class AxisChartScaffoldWidget extends StatelessWidget {
       widgets.insert(
         insertIndex(data.titlesData.topTitles.drawBelowEverything),
         SideTitlesWidget(
-          side: TitlesSide.top,
+          side: AxisSide.top,
           axisChartData: data,
           parentSize: constraints.biggest,
         ),
@@ -86,7 +86,7 @@ class AxisChartScaffoldWidget extends StatelessWidget {
       widgets.insert(
         insertIndex(data.titlesData.rightTitles.drawBelowEverything),
         SideTitlesWidget(
-          side: TitlesSide.right,
+          side: AxisSide.right,
           axisChartData: data,
           parentSize: constraints.biggest,
         ),
@@ -97,7 +97,7 @@ class AxisChartScaffoldWidget extends StatelessWidget {
       widgets.insert(
         insertIndex(data.titlesData.bottomTitles.drawBelowEverything),
         SideTitlesWidget(
-          side: TitlesSide.bottom,
+          side: AxisSide.bottom,
           axisChartData: data,
           parentSize: constraints.biggest,
         ),

--- a/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
@@ -21,40 +21,6 @@ class SideTitleWidget extends StatelessWidget {
     this.angle = 0.0,
   }) : super(key: key);
 
-  Widget spacedTitle({
-    required TitleMeta meta,
-    required Widget widget,
-    double spaceToChart = 8.0,
-  }) {
-    switch (meta.axisSide) {
-      case AxisSide.left:
-        return Container(
-          margin: EdgeInsets.only(right: spaceToChart),
-          child: widget,
-        );
-      case AxisSide.top:
-        return Align(
-          alignment: Alignment.bottomCenter,
-          child: Container(
-            margin: EdgeInsets.only(bottom: spaceToChart),
-            child: widget,
-          ),
-        );
-      case AxisSide.right:
-        return Container(
-          margin: EdgeInsets.only(left: spaceToChart),
-          child: widget,
-        );
-      case AxisSide.bottom:
-        return Container(
-          margin: EdgeInsets.only(top: spaceToChart),
-          child: widget,
-        );
-      default:
-        throw StateError("Invalid side");
-    }
-  }
-
   Alignment _getAlignment() {
     switch (axisSide) {
       case AxisSide.left:

--- a/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
@@ -1,0 +1,99 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/widgets.dart';
+
+/// Wraps a widget and applies some default behaviours
+///
+/// You need to pass [axisSide] value that provided by [TitleMeta]
+/// It forces the widget to be close to the chart.
+/// It also applies a [space] to the chart.
+/// You can also fill [angle] in radians if you need to rotate your widget.
+class SideTitleWidget extends StatelessWidget {
+  final AxisSide axisSide;
+  final double space;
+  final Widget child;
+  final double angle;
+
+  const SideTitleWidget({
+    Key? key,
+    required this.child,
+    required this.axisSide,
+    this.space = 8.0,
+    this.angle = 0.0,
+  }) : super(key: key);
+
+  Widget spacedTitle({
+    required TitleMeta meta,
+    required Widget widget,
+    double spaceToChart = 8.0,
+  }) {
+    switch (meta.axisSide) {
+      case AxisSide.left:
+        return Container(
+          margin: EdgeInsets.only(right: spaceToChart),
+          child: widget,
+        );
+      case AxisSide.top:
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: Container(
+            margin: EdgeInsets.only(bottom: spaceToChart),
+            child: widget,
+          ),
+        );
+      case AxisSide.right:
+        return Container(
+          margin: EdgeInsets.only(left: spaceToChart),
+          child: widget,
+        );
+      case AxisSide.bottom:
+        return Container(
+          margin: EdgeInsets.only(top: spaceToChart),
+          child: widget,
+        );
+      default:
+        throw StateError("Invalid side");
+    }
+  }
+
+  Alignment _getAlignment() {
+    switch (axisSide) {
+      case AxisSide.left:
+        return Alignment.centerRight;
+      case AxisSide.top:
+        return Alignment.bottomCenter;
+      case AxisSide.right:
+        return Alignment.centerLeft;
+      case AxisSide.bottom:
+        return Alignment.topCenter;
+      default:
+        throw StateError("Invalid side");
+    }
+  }
+
+  EdgeInsets _getMargin() {
+    switch (axisSide) {
+      case AxisSide.left:
+        return EdgeInsets.only(right: space);
+      case AxisSide.top:
+        return EdgeInsets.only(bottom: space);
+      case AxisSide.right:
+        return EdgeInsets.only(left: space);
+      case AxisSide.bottom:
+        return EdgeInsets.only(top: space);
+      default:
+        throw StateError("Invalid side");
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Transform.rotate(
+      angle: angle,
+      child: Container(
+        margin: _getMargin(),
+        alignment: _getAlignment(),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
@@ -1,8 +1,9 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/widgets.dart';
 
-/// Wraps a widget and applies some default behaviours
+/// Wraps a [child] widget and applies some default behaviours
 ///
+/// Recommended to be used in [SideTitles.getTitlesWidget]
 /// You need to pass [axisSide] value that provided by [TitleMeta]
 /// It forces the widget to be close to the chart.
 /// It also applies a [space] to the chart.

--- a/lib/src/chart/base/axis_chart/side_titles/side_titles_widget.dart
+++ b/lib/src/chart/base/axis_chart/side_titles/side_titles_widget.dart
@@ -46,8 +46,7 @@ class SideTitlesWidget extends StatelessWidget {
 
   bool get isLeftOrTop => side == AxisSide.left || side == AxisSide.top;
 
-  bool get isRightOrBottom =>
-      side == AxisSide.right || side == AxisSide.bottom;
+  bool get isRightOrBottom => side == AxisSide.right || side == AxisSide.bottom;
 
   AxisTitles get axisTitles {
     switch (side) {
@@ -103,21 +102,6 @@ class SideTitlesWidget extends StatelessWidget {
     }
   }
 
-  Alignment getTitlesAlignment(AxisSide side) {
-    switch (side) {
-      case AxisSide.left:
-        return Alignment.centerRight;
-      case AxisSide.top:
-        return Alignment.bottomCenter;
-      case AxisSide.right:
-        return Alignment.centerLeft;
-      case AxisSide.bottom:
-        return Alignment.topCenter;
-      default:
-        throw StateError("Invalid side");
-    }
-  }
-
   List<AxisSideTitleWidgetHolder> makeWidgets(
     double axisViewSize,
     double axisMin,
@@ -155,29 +139,24 @@ class SideTitlesWidget extends StatelessWidget {
         return AxisSideTitleMetaData(axisValue, axisLocation);
       }).toList();
     }
-    return axisPositions
-        .map(
-          (metaData) {
-            return AxisSideTitleWidgetHolder(
-              metaData,
-              Align(
-                alignment: getTitlesAlignment(side),
-                child: sideTitles.getTitlesWidget(
-                  metaData.axisValue,
-                  TitleMeta(
-                    min: axisMin,
-                    max: axisMax,
-                    appliedInterval: interval,
-                    sideTitles: sideTitles,
-                    formattedValue: Utils().formatNumber(metaData.axisValue),
-                    axisSide: side,
-                  ),
-                ),
-              ),
-            );
-          },
-        )
-        .toList();
+    return axisPositions.map(
+      (metaData) {
+        return AxisSideTitleWidgetHolder(
+          metaData,
+          sideTitles.getTitlesWidget(
+            metaData.axisValue,
+            TitleMeta(
+              min: axisMin,
+              max: axisMax,
+              appliedInterval: interval,
+              sideTitles: sideTitles,
+              formattedValue: Utils().formatNumber(metaData.axisValue),
+              axisSide: side,
+            ),
+          ),
+        );
+      },
+    ).toList();
   }
 
   @override

--- a/lib/src/chart/base/axis_chart/side_titles/side_titles_widget.dart
+++ b/lib/src/chart/base/axis_chart/side_titles/side_titles_widget.dart
@@ -8,10 +8,8 @@ import 'package:flutter/material.dart';
 import '../axis_chart_helper.dart';
 import 'side_titles_flex.dart';
 
-enum TitlesSide { left, top, right, bottom }
-
 class SideTitlesWidget extends StatelessWidget {
-  final TitlesSide side;
+  final AxisSide side;
   final AxisChartData axisChartData;
   final Size parentSize;
 
@@ -22,7 +20,7 @@ class SideTitlesWidget extends StatelessWidget {
     required this.parentSize,
   }) : super(key: key);
 
-  bool get isHorizontal => side == TitlesSide.top || side == TitlesSide.bottom;
+  bool get isHorizontal => side == AxisSide.top || side == AxisSide.bottom;
 
   bool get isVertical => !isHorizontal;
 
@@ -46,20 +44,20 @@ class SideTitlesWidget extends StatelessWidget {
 
   FlTitlesData get titlesData => axisChartData.titlesData;
 
-  bool get isLeftOrTop => side == TitlesSide.left || side == TitlesSide.top;
+  bool get isLeftOrTop => side == AxisSide.left || side == AxisSide.top;
 
   bool get isRightOrBottom =>
-      side == TitlesSide.right || side == TitlesSide.bottom;
+      side == AxisSide.right || side == AxisSide.bottom;
 
   AxisTitles get axisTitles {
     switch (side) {
-      case TitlesSide.left:
+      case AxisSide.left:
         return titlesData.leftTitles;
-      case TitlesSide.top:
+      case AxisSide.top:
         return titlesData.topTitles;
-      case TitlesSide.right:
+      case AxisSide.right:
         return titlesData.rightTitles;
-      case TitlesSide.bottom:
+      case AxisSide.bottom:
         return titlesData.bottomTitles;
     }
   }
@@ -72,36 +70,51 @@ class SideTitlesWidget extends StatelessWidget {
 
   Alignment get alignment {
     switch (side) {
-      case TitlesSide.left:
+      case AxisSide.left:
         return Alignment.centerLeft;
-      case TitlesSide.top:
+      case AxisSide.top:
         return Alignment.topCenter;
-      case TitlesSide.right:
+      case AxisSide.right:
         return Alignment.centerRight;
-      case TitlesSide.bottom:
+      case AxisSide.bottom:
         return Alignment.bottomCenter;
     }
   }
 
   EdgeInsets get thisSidePadding {
     switch (side) {
-      case TitlesSide.right:
-      case TitlesSide.left:
+      case AxisSide.right:
+      case AxisSide.left:
         return titlesData.allSidesPadding.onlyTopBottom;
-      case TitlesSide.top:
-      case TitlesSide.bottom:
+      case AxisSide.top:
+      case AxisSide.bottom:
         return titlesData.allSidesPadding.onlyLeftRight;
     }
   }
 
   double get thisSidePaddingTotal {
     switch (side) {
-      case TitlesSide.right:
-      case TitlesSide.left:
+      case AxisSide.right:
+      case AxisSide.left:
         return titlesData.allSidesPadding.vertical;
-      case TitlesSide.top:
-      case TitlesSide.bottom:
+      case AxisSide.top:
+      case AxisSide.bottom:
         return titlesData.allSidesPadding.horizontal;
+    }
+  }
+
+  Alignment getTitlesAlignment(AxisSide side) {
+    switch (side) {
+      case AxisSide.left:
+        return Alignment.centerRight;
+      case AxisSide.top:
+        return Alignment.bottomCenter;
+      case AxisSide.right:
+        return Alignment.centerLeft;
+      case AxisSide.bottom:
+        return Alignment.topCenter;
+      default:
+        throw StateError("Invalid side");
     }
   }
 
@@ -109,6 +122,7 @@ class SideTitlesWidget extends StatelessWidget {
     double axisViewSize,
     double axisMin,
     double axisMax,
+    AxisSide side,
   ) {
     List<AxisSideTitleMetaData> axisPositions;
     final interval = sideTitles.interval ??
@@ -143,19 +157,25 @@ class SideTitlesWidget extends StatelessWidget {
     }
     return axisPositions
         .map(
-          (metaData) => AxisSideTitleWidgetHolder(
-            metaData,
-            sideTitles.getTitlesWidget(
-              metaData.axisValue,
-              TitleMeta(
-                axisMin,
-                axisMax,
-                interval,
-                sideTitles,
-                Utils().formatNumber(metaData.axisValue),
+          (metaData) {
+            return AxisSideTitleWidgetHolder(
+              metaData,
+              Align(
+                alignment: getTitlesAlignment(side),
+                child: sideTitles.getTitlesWidget(
+                  metaData.axisValue,
+                  TitleMeta(
+                    min: axisMin,
+                    max: axisMax,
+                    appliedInterval: interval,
+                    sideTitles: sideTitles,
+                    formattedValue: Utils().formatNumber(metaData.axisValue),
+                    axisSide: side,
+                  ),
+                ),
               ),
-            ),
-          ),
+            );
+          },
         )
         .toList();
   }
@@ -195,6 +215,7 @@ class SideTitlesWidget extends StatelessWidget {
                   axisViewSize - thisSidePaddingTotal,
                   axisMin,
                   axisMax,
+                  side,
                 ),
               ),
             ),
@@ -212,7 +233,7 @@ class SideTitlesWidget extends StatelessWidget {
 
 class _AxisTitleWidget extends StatelessWidget {
   final AxisTitles axisTitles;
-  final TitlesSide side;
+  final AxisSide side;
   final double axisViewSize;
 
   const _AxisTitleWidget({
@@ -224,18 +245,18 @@ class _AxisTitleWidget extends StatelessWidget {
 
   int get axisNameQuarterTurns {
     switch (side) {
-      case TitlesSide.right:
+      case AxisSide.right:
         return 3;
-      case TitlesSide.left:
+      case AxisSide.left:
         return 3;
-      case TitlesSide.top:
+      case AxisSide.top:
         return 0;
-      case TitlesSide.bottom:
+      case AxisSide.bottom:
         return 0;
     }
   }
 
-  bool get isHorizontal => side == TitlesSide.top || side == TitlesSide.bottom;
+  bool get isHorizontal => side == AxisSide.top || side == AxisSide.bottom;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/chart/base/base_chart/base_chart_data.dart
+++ b/lib/src/chart/base/base_chart/base_chart_data.dart
@@ -173,39 +173,6 @@ class FlClipData with EquatableMixin {
   List<Object?> get props => [top, bottom, left, right];
 }
 
-class TitleMeta {
-  final double min;
-  final double max;
-  final double appliedInterval;
-  final SideTitles sideTitles;
-  final String formattedValue;
-
-  TitleMeta(this.min, this.max, this.appliedInterval, this.sideTitles,
-      this.formattedValue);
-}
-
-/// It gives you the axis value and gets a String value based on it.
-typedef GetTitleWidgetFunction = Widget Function(double value, TitleMeta meta);
-
-/// The default [SideTitles.getTitlesWidget] function.
-///
-/// formats the axis number to a shorter string using [formatNumber].
-Widget defaultGetTitle(double value, TitleMeta meta) {
-  return Text(meta.formattedValue);
-}
-
-/// It gives you the axis value and gets a TextStyle based on given value
-///
-/// If you return null, we try to provide an inherited TextStyle using theme.
-/// (you can customize a specific title using this).
-typedef GetTitleTextStyleFunction = TextStyle? Function(
-    BuildContext context, double value);
-
-/// The default [SideTitles.getTextStyles] function.
-///
-/// returns a black TextStyle with 11 fontSize for all values.
-TextStyle? defaultGetTitleTextStyle(BuildContext context, double value) => null;
-
 /// Chart's touch callback.
 typedef BaseTouchCallback<R extends BaseTouchResponse> = void Function(
     FlTouchEvent, R?);

--- a/lib/src/utils/canvas_wrapper.dart
+++ b/lib/src/utils/canvas_wrapper.dart
@@ -9,7 +9,6 @@ import 'package:flutter/cupertino.dart' hide Image;
 ///
 /// We wrapped the canvas here, because we needed to write tests for our drawing system.
 /// Now in tests we can verify that these functions called with a specific value.
-@Deprecated('We can use the [Canvas] directly to write unit tests')
 class CanvasWrapper {
   final Canvas canvas;
   final Size size;

--- a/test/chart/base/axis_chart/axis_chart_scaffold_widget_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_scaffold_widget_test.dart
@@ -1,6 +1,5 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_scaffold_widget.dart';
-import 'package:fl_chart/src/chart/base/axis_chart/side_titles/side_titles_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -199,19 +198,19 @@ void main() {
         ),
       );
 
-      Future checkSide(TitlesSide side) async {
+      Future checkSide(AxisSide side) async {
         String axisChar;
         switch (side) {
-          case TitlesSide.left:
+          case AxisSide.left:
             axisChar = 'L';
             break;
-          case TitlesSide.top:
+          case AxisSide.top:
             axisChar = 'T';
             break;
-          case TitlesSide.right:
+          case AxisSide.right:
             axisChar = 'R';
             break;
-          case TitlesSide.bottom:
+          case AxisSide.bottom:
             axisChar = 'B';
             break;
           default:
@@ -224,16 +223,16 @@ void main() {
 
       expect(chartDrawingSize, const Size(320, 280));
       expect(find.byIcon(Icons.arrow_left), findsOneWidget);
-      checkSide(TitlesSide.left);
+      checkSide(AxisSide.left);
 
       expect(find.byIcon(Icons.arrow_drop_up), findsOneWidget);
-      checkSide(TitlesSide.top);
+      checkSide(AxisSide.top);
 
       expect(find.byIcon(Icons.arrow_right), findsOneWidget);
-      checkSide(TitlesSide.right);
+      checkSide(AxisSide.right);
 
       expect(find.byIcon(Icons.arrow_drop_down), findsOneWidget);
-      checkSide(TitlesSide.bottom);
+      checkSide(AxisSide.bottom);
 
       expect(find.byType(Text), findsNWidgets(44));
       expect(find.byType(Icon), findsNWidgets(4));

--- a/test/chart/base/axis_chart/axis_chart_widgets_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_widgets_test.dart
@@ -4,16 +4,68 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets(
-    'SideTitleWidget',
+    'SideTitleWidget left',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: Center(
-              child: SideTitleWidget(
-                axisSide: AxisSide.left,
-                child: Text("1s"),
-              ),
+            body: SideTitleWidget(
+              axisSide: AxisSide.left,
+              child: Text("1s"),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(Container), findsOneWidget);
+      expect(find.text('1s'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'SideTitleWidget top',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SideTitleWidget(
+              axisSide: AxisSide.top,
+              child: Text("1s"),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(Container), findsOneWidget);
+      expect(find.text('1s'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'SideTitleWidget right',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SideTitleWidget(
+              axisSide: AxisSide.right,
+              child: Text("1s"),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(Container), findsOneWidget);
+      expect(find.text('1s'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'SideTitleWidget bottom',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SideTitleWidget(
+              axisSide: AxisSide.bottom,
+              child: Text("1s"),
             ),
           ),
         ),

--- a/test/chart/base/axis_chart/axis_chart_widgets_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_widgets_test.dart
@@ -1,0 +1,25 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'SideTitleWidget',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SideTitleWidget(
+                axisSide: AxisSide.left,
+                child: Text("1s"),
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(Container), findsOneWidget);
+      expect(find.text('1s'), findsOneWidget);
+    },
+  );
+}

--- a/test/chart/base/axis_chart/side_titles/side_titles_widget_test.dart
+++ b/test/chart/base/axis_chart/side_titles/side_titles_widget_test.dart
@@ -205,7 +205,7 @@ void main() {
                 width: viewSize.width,
                 height: viewSize.height,
                 child: SideTitlesWidget(
-                  side: TitlesSide.left,
+                  side: AxisSide.left,
                   axisChartData: lineChartDataWithNoTitles,
                   parentSize: viewSize,
                 ),
@@ -222,7 +222,7 @@ void main() {
   testWidgets(
     'LineChart with all titles',
     (WidgetTester tester) async {
-      Future checkSide(TitlesSide side) async {
+      Future checkSide(AxisSide side) async {
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
@@ -243,16 +243,16 @@ void main() {
 
         String axisName;
         switch (side) {
-          case TitlesSide.left:
+          case AxisSide.left:
             axisName = 'Left';
             break;
-          case TitlesSide.top:
+          case AxisSide.top:
             axisName = 'Top';
             break;
-          case TitlesSide.right:
+          case AxisSide.right:
             axisName = 'Right';
             break;
-          case TitlesSide.bottom:
+          case AxisSide.bottom:
             axisName = 'Bottom';
             break;
           default:
@@ -264,10 +264,10 @@ void main() {
         }
       }
 
-      await checkSide(TitlesSide.left);
-      await checkSide(TitlesSide.top);
-      await checkSide(TitlesSide.right);
-      await checkSide(TitlesSide.bottom);
+      await checkSide(AxisSide.left);
+      await checkSide(AxisSide.top);
+      await checkSide(AxisSide.right);
+      await checkSide(AxisSide.bottom);
     },
   );
 
@@ -282,7 +282,7 @@ void main() {
                 width: viewSize.width,
                 height: viewSize.height,
                 child: SideTitlesWidget(
-                  side: TitlesSide.left,
+                  side: AxisSide.left,
                   axisChartData: lineChartDataWithOnlyLeftTitles,
                   parentSize: viewSize,
                 ),
@@ -311,7 +311,7 @@ void main() {
                 width: viewSize.width,
                 height: viewSize.height,
                 child: SideTitlesWidget(
-                  side: TitlesSide.left,
+                  side: AxisSide.left,
                   axisChartData: lineChartDataWithOnlyLeftTitlesWithoutAxisName,
                   parentSize: viewSize,
                 ),
@@ -339,7 +339,7 @@ void main() {
                 width: viewSize.width,
                 height: viewSize.height,
                 child: SideTitlesWidget(
-                  side: TitlesSide.bottom,
+                  side: AxisSide.bottom,
                   axisChartData: barChartDataWithOnlyBottomTitles,
                   parentSize: viewSize,
                 ),
@@ -368,7 +368,7 @@ void main() {
                 width: viewSize.width,
                 height: viewSize.height,
                 child: SideTitlesWidget(
-                  side: TitlesSide.right,
+                  side: AxisSide.right,
                   axisChartData: barChartDataWithOnlyRightTitles,
                   parentSize: viewSize,
                 ),


### PR DESCRIPTION
* **FEATURE** Add `SideTitleWidget` to help you use it in [SideTitles.getTitlesWidget]. It's a wrapper around your widget. It keeps your provided `child` widget close to the chart. It has `angle` and `space` properties to handle margin and rotation. There is a `axisSide` property that you should fill, it has provided to you in the MetaData object. Check the below sample:
```dart
getTitlesWidget: (double value, TitleMeta meta) {
  return SideTitleWidget(
    axisSide: meta.axisSide,
    space: 8.0,
    angle: 0.0,
    child: const Text("This is your widget"),
  );
},
```