### PR TITLE
fix: Uneven titles in RadarChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## newVersion
+* **BUGFIX** (by @ateich): Fix uneven titles in RadarChart when using titlePositionPercentageOffset, #1074.
+
 ## 0.55.0
 * **FEATURE** (by @emelinepal): Add `tooltipBorder` property in [LineTouchTooltipData], [BarTouchTooltipData], [ScatterTouchTooltipData], #692.
 * **BUGFIX** (by @imaNNeoFighT): Fix tooltip issue on negative bar charts, #978.

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -218,7 +218,7 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
       final titleX = centerX +
           cos(angle) * (radius * threshold + (_titleTextPaint.height / 2));
       final titleY = centerY +
-          sin(angle) * (radius + threshold + (_titleTextPaint.height / 2));
+          sin(angle) * (radius * threshold + (_titleTextPaint.height / 2));
 
       Rect rect = Rect.fromLTWH(
         titleX,


### PR DESCRIPTION
Fixes an issue where titles are displayed at an uneven distance from a RadarChart when titlePositionPercentageOffset is used.

Resolves #1074