### PR TITLE
fix: RadarChart crashes if all values in RadarDataSet are equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## newVersion
+* **BUGFIX** (by @ateich): Fix infinite loop in RadarChart when all values in RadarDataSet are equal, #882.
 * **BUGFIX** (by @ateich): Fix uneven titles in RadarChart when using titlePositionPercentageOffset, #1074.
 
 ## 0.55.0

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -99,13 +99,12 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
     final dataSetMaxValue = data.maxEntry.value;
     final dataSetMinValue = data.minEntry.value;
     final tickSpace = (dataSetMaxValue - dataSetMinValue) / data.tickCount;
-
     final ticks = <double>[];
+    double tickValue = dataSetMinValue;
 
-    for (var tick = dataSetMinValue;
-        tick <= dataSetMaxValue;
-        tick = tick + tickSpace) {
-      ticks.add(tick);
+    for (var i = 0; i <= data.tickCount; i++) {
+      ticks.add(tickValue);
+      tickValue += tickSpace;
     }
 
     final tickDistance = radius / (ticks.length);


### PR DESCRIPTION
If the max and min values in a RadarDataSet are equal, the `drawTicks` method in `radar_chart_painter.dart` will enter an infinite loop.

This is due to a for loop that fails to be incremented if the max and min values are equal, causing the loop to never meet its exit condition.

I have replaced the for loop with one that will always exit.

Resolves #882