### PR TITLE
Bump version to 0.55.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## newVersion
+## 0.55.1
 * **BUGFIX** (by @ateich): Fix infinite loop in RadarChart when all values in RadarDataSet are equal, #882.
 * **BUGFIX** (by @ateich): Fix uneven titles in RadarChart when using titlePositionPercentageOffset, #1074.
 * **BUGFIX** (by @imaNNeoFighT): Fix PieChart single section stroke issue, #1089

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A powerful Flutter chart library, currently supporting Line Chart, Bar Chart and Pie Chart.
-version: 0.55.0
+version: 0.55.1
 homepage: https://github.com/imaNNeoFighT/fl_chart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   equatable: ^2.0.3
 
 dev_dependencies:
-  mockito: ^5.1.0
-  build_runner: ^2.1.10
+  mockito: ^5.3.0
+  build_runner: ^2.2.0
   flutter_lints: ^2.0.1
   vector_math: ^2.1.2 #Added to use in some generated codes of mockito
   flutter_test:


### PR DESCRIPTION
* **BUGFIX** (by @ateich): Fix infinite loop in RadarChart when all values in RadarDataSet are equal, #882.
* **BUGFIX** (by @ateich): Fix uneven titles in RadarChart when using titlePositionPercentageOffset, #1074.
* **BUGFIX** (by @imaNNeoFighT): Fix PieChart single section stroke issue, #1089
